### PR TITLE
Added extra cache control options for media downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluecadet/launchpad",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Suite of tools to manage media installations",
   "engines": {
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "formdata-node": "^4.3.1",
     "fs-extra": "^10.0.0",
     "get-urls": "^10.0.0",
-    "got": "^11.8.2",
+    "got": "^12.3.0",
     "jsonpath": "^1.1.1",
     "logform": "^2.3.2",
     "markdown-it": "^12.2.0",

--- a/packages/content/lib/content-options.js
+++ b/packages/content/lib/content-options.js
@@ -16,12 +16,14 @@ export class ContentOptions {
     backupPath = `${Constants.DOWNLOAD_PATH_TOKEN}/.backups/`,
     backupAndRestore = true,
     maxConcurrent = 4,
+    maxTimeout = 30000,
     clearOldFilesOnStart = false,
     clearOldFilesOnSuccess = true,
     keep = '',
     strip = '',
     ignoreCache = false,
-    skipModifiedCheck = false,
+    enableIfModifiedSinceCheck = true,
+    enableContentLengthCheck = true,
     abortOnError = true,
     ignoreImageTransformErrors = true,
     forceClearTempFiles = true,
@@ -63,9 +65,15 @@ export class ContentOptions {
     
     /**
      * Max concurrent downloads.
-     * @type {boolean}
+     * @type {number}
      */
     this.maxConcurrent = maxConcurrent;
+    
+    /**
+     * Max request timeout in ms.
+     * @type {number}
+     */
+    this.maxTimeout = maxTimeout;
     
     /**
      * Remove all existing files in dest dir when downloads succeed. Ignores files that match `keep`
@@ -98,10 +106,16 @@ export class ContentOptions {
     this.ignoreCache = ignoreCache;
     
     /**
-     * Ignores the HTTP if modified check and only compare cached files for their existance
+     * Enables the HTTP if-modified-since check. Disabling this will assume that the local file is the same as the remote file if it already exists. Defaults to true.
      * @type {boolean}
      */
-    this.skipModifiedCheck = skipModifiedCheck;
+    this.enableIfModifiedSinceCheck = enableIfModifiedSinceCheck;
+    
+    /**
+     * Compares the HTTP header content-length with the local file size. Disabling this will assume that the local file is the same as the remote file if it already exists. Defaults to true.
+     * @type {boolean}
+     */
+    this.enableContentLengthCheck = enableContentLengthCheck;
     
     /**
      * If set to true, errors will cause syncing to abort all remaining tasks immediately

--- a/packages/content/lib/utils/media-downloader.js
+++ b/packages/content/lib/utils/media-downloader.js
@@ -201,6 +201,7 @@ export class MediaDownloader {
         let response = null;
         
         if (options.enableIfModifiedSinceCheck || options.enableContentLengthCheck) {
+          // Get just the file header to check for modified date and file size
           response = await got.head(urlString, {
             headers: this._getRequestHeaders(destPath),
             timeout: {

--- a/packages/content/lib/utils/media-downloader.js
+++ b/packages/content/lib/utils/media-downloader.js
@@ -105,6 +105,7 @@ export class MediaDownloader {
             };
           })
           .catch((error) => {
+            console.log(error);
             if (options.abortOnError) {
               throw error;
             }
@@ -189,21 +190,40 @@ export class MediaDownloader {
       let tempFilePath = path.join(tempDir, relativePath);
       let tempFilePathDir = path.dirname(tempFilePath);
       let isCached = false;
+      
       fs.ensureDirSync(tempFilePathDir);
       
+      const exists = fs.existsSync(destPath);
+      const stats = exists ? fs.lstatSync(destPath) : null;
+      
       // check for cached image first
-      if (!options.ignoreCache && fs.existsSync(destPath) && fs.lstatSync(destPath).isFile()) {
+      if (!options.ignoreCache && exists && stats.isFile()) {
         let response = null;
-
-        if (!options.skipModifiedCheck) {
+        
+        if (options.enableIfModifiedSinceCheck || options.enableContentLengthCheck) {
           response = await got.head(urlString, {
-            // check if we have the file on cache
             headers: this._getRequestHeaders(destPath),
-            timeout: 30000, // ms
+            timeout: {
+              response: options.maxTimeout
+            }
           });
         }
-
-        if (options.skipModifiedCheck || response.statusCode === 304) {
+        
+        let isRemoteNew = false;
+        
+        if (options.enableIfModifiedSinceCheck) {
+          // Remote file has been modified since the local file changed
+          isRemoteNew = isRemoteNew || (response.statusCode !== 304);
+        }
+        
+        if (options.enableContentLengthCheck && response.headers && response.headers['content-length']) {
+          // Remote file has a different size than the local file
+          const remoteSize = parseInt(response.headers['content-length']);
+          const localSize  = stats.size;
+          isRemoteNew = isRemoteNew || (remoteSize !== localSize);
+        }
+        
+        if (!isRemoteNew) {
           // copy existing, cached file from dest dir
           fs.copyFileSync(destPath, tempFilePath);
           isCached = true;
@@ -215,7 +235,7 @@ export class MediaDownloader {
         await pipeline(
           got.stream(urlString, {
             timeout: {
-              response: 30000, // ms for initial response
+              response: options.maxTimeout
             },
           }),
           fs.createWriteStream(tempFilePath)

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -36,7 +36,7 @@
     "formdata-node": "^4.3.1",
     "fs-extra": "^10.0.0",
     "get-urls": "^10.0.0",
-    "got": "^11.8.2",
+    "got": "^12.3.0",
     "jsonpath": "^1.1.1",
     "markdown-it": "^12.2.0",
     "p-queue": "^7.1.0",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluecadet/launchpad-content",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Content syncing pipeline for various sources",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
- **Requires upgrade of got**: Run `npm i` after updating if you're developing launchpad
- Renamed `skippedModifiedCheck` to `enableIfModifiedSinceCheck` and defaulted it to `true`
- Added `enableIfModifiedSinceCheck`, which will compare a locally cached file's size in bytes to the HTTP header's `content-length` property.

This is helpful if a file was corrupted, but can also be used if your server doesn't properly respond with `304` (see https://github.com/sanity-io/sanity/issues/3474) by setting `enableIfModifiedSinceCheck` to false and relying exclusively on local file-size comparison for cache checks.

Possible side-effect: If a file was changed remotely but is exactly the same size, it will not be updated! Possible future workaround is to _also_ look at the `age` HTTP response property, but that requires further logic and testing against other CDNs.