### PR TITLE
Connect to pm2 in `no-daemon-mode`

### DIFF
--- a/.changeset/famous-ears-beam.md
+++ b/.changeset/famous-ears-beam.md
@@ -1,0 +1,6 @@
+---
+"@bluecadet/launchpad-monitor": minor
+"@bluecadet/launchpad-utils": patch
+---
+
+connect to pm2 using `no-daemon-mode`, and route console method calls to the parent logger

--- a/packages/content/test/config.js
+++ b/packages/content/test/config.js
@@ -12,62 +12,69 @@ const config = {
   },
   "sources": [
     {
-      "id": "spaceships",
+      "id": "dummyjson",
       "type": "json",
       "files": {
-          "spaceships.json": "https://api.flickr.com/services/feeds/photos_public.gne?format=json&nojsoncallback=1&tags=spaceship",
-          "rockets.json": "https://api.flickr.com/services/feeds/photos_public.gne?format=json&nojsoncallback=1&tags=rocket"
-      },
-      "strip": "services/feeds/",
-      "imageTransforms": [
-        {"scale": 0.75}
-      ]
-    },
-    {
-      "id": "astronauts",
-      "files": {
-        "astronauts.json": "https://api.flickr.com/services/feeds/photos_public.gne?format=json&nojsoncallback=1&tags=astronauts"
-      },
-      "strip": "services/feeds/"
-    },
-    {
-      "id": "strapiTest",
-      "type": "strapi",
-      "version": 3,
-      "baseUrl": "http:localhost:1337/",
-      "queries": ["poems"],
-      "limit": 100,
-      "maxNumPages": -1,
-      "pageNumZeroPad": 0,
-    },
-    {
-      "id": "contentfulTest",
-      "type": "contentful",
-      "space": "qc670l0h4zjf",
-      "locale": "en-US",
-      "filename": "content.json",
-      "protocol": "https",
-      "searchParams": {
-        "limit": 1000,
-        "include": 10
-      },
-      "contentTypes": [],
-      "imageParams": {
-        "f": "face",
-        "fit": "crop",
-        "w": 512,
-        "h": 512
+        "photos.json": "https://dummyjson.com/products"
       }
     },
-    {
-      "id": "airtableTest",
-      "type": "airtable",
-      "baseId": "apppsX7HeYHO7rMjd",
-      "defaultView": "Grid view",
-      "tables": ["data"],
-      "keyValueTables": ["settings"],
-      "appendLocalAttachmentPaths": true,
-    }
+    // {
+    //   "id": "spaceships",
+    //   "type": "json",
+    //   "files": {
+    //       "spaceships.json": "https://api.flickr.com/services/feeds/photos_public.gne?format=json&nojsoncallback=1&tags=spaceship",
+    //       "rockets.json": "https://api.flickr.com/services/feeds/photos_public.gne?format=json&nojsoncallback=1&tags=rocket"
+    //   },
+    //   "strip": "services/feeds/",
+    //   "imageTransforms": [
+    //     {"scale": 0.75}
+    //   ]
+    // },
+    // {
+    //   "id": "astronauts",
+    //   "files": {
+    //     "astronauts.json": "https://api.flickr.com/services/feeds/photos_public.gne?format=json&nojsoncallback=1&tags=astronauts"
+    //   },
+    //   "strip": "services/feeds/"
+    // },
+    // {
+    //   "id": "strapiTest",
+    //   "type": "strapi",
+    //   "version": 3,
+    //   "baseUrl": "http:localhost:1337/",
+    //   "queries": ["poems"],
+    //   "limit": 100,
+    //   "maxNumPages": -1,
+    //   "pageNumZeroPad": 0,
+    // },
+    // {
+    //   "id": "contentfulTest",
+    //   "type": "contentful",
+    //   "space": "qc670l0h4zjf",
+    //   "locale": "en-US",
+    //   "filename": "content.json",
+    //   "protocol": "https",
+    //   "searchParams": {
+    //     "limit": 1000,
+    //     "include": 10
+    //   },
+    //   "contentTypes": [],
+    //   "imageParams": {
+    //     "f": "face",
+    //     "fit": "crop",
+    //     "w": 512,
+    //     "h": 512
+    //   }
+    // },
+    // {
+    //   "id": "airtableTest",
+    //   "type": "airtable",
+    //   "baseId": "apppsX7HeYHO7rMjd",
+    //   "defaultView": "Grid view",
+    //   "tables": ["data"],
+    //   "keyValueTables": ["settings"],
+    //   "appendLocalAttachmentPaths": true,
+    // }
   ]
 };
 

--- a/packages/launchpad/docs/logging.md
+++ b/packages/launchpad/docs/logging.md
@@ -46,6 +46,7 @@ See: https://github.com/winstonjs/winston#creating-your-own-logger for all avail
 | <a name="module_log-manager.LogOptions+fileOptions">`fileOptions`</a> |  <code>LogFileOptions</code>|  <code>new LogFileOptions(fileOptions)</code>  | Options for individual files and streams. |
 | <a name="module_log-manager.LogOptions+level">`level`</a> |  <code>string</code>|  <code>'info'</code>  | The maximum log level to display in all default logs. |
 | <a name="module_log-manager.LogOptions+format">`format`</a> |  <code>winston.Logform.Format</code>|  <code>LogOptions.DEFAULT\_LOG\_FORMAT</code>  | The format for how each line is logged. |
+| <a name="module_log-manager.LogOptions+overrideConsole">`overrideConsole`</a> |  <code>boolean</code>|  <code>true</code>  | Route all console logs to the log manager. This helps<br>ensure that logs are routed to files and rotated properly.<br><br>This will also freeze the console object, so it can't be<br>modified further during runtime.<br><br>All console logs will be prefixed with `(console)`. |
 
 
 ###  LogFileOptions

--- a/packages/launchpad/index.js
+++ b/packages/launchpad/index.js
@@ -4,7 +4,7 @@ import { LaunchpadCore } from './lib/launchpad-core.js';
 import { launch as launchContent } from '@bluecadet/launchpad-content';
 import { launch as launchMonitor, LaunchpadMonitor } from '@bluecadet/launchpad-monitor';
 import { launch as launchScaffold } from '@bluecadet/launchpad-scaffold';
-import { launchFromCli, onExit } from '@bluecadet/launchpad-utils';
+import { launchFromCli } from '@bluecadet/launchpad-utils';
 
 export default LaunchpadCore;
 
@@ -44,10 +44,6 @@ launchFromCli(import.meta, {
 	}
 }).then(async config => {
 	const launchpad = new LaunchpadCore(config);
-	
-	onExit(async () => {
-		await launchpad.shutdown();
-	});
 	
 	switch (config.startupCommand) {
 		case StartupCommands.SCAFFOLD: {

--- a/packages/launchpad/lib/launchpad-core.js
+++ b/packages/launchpad/lib/launchpad-core.js
@@ -5,7 +5,7 @@
 import autoBind from 'auto-bind';
 
 import LaunchpadOptions from './launchpad-options.js';
-import { LogManager, Logger } from '@bluecadet/launchpad-utils';
+import { LogManager, Logger, onExit } from '@bluecadet/launchpad-utils';
 import LaunchpadContent from '@bluecadet/launchpad-content';
 import LaunchpadMonitor from '@bluecadet/launchpad-monitor';
 import CommandCenter, { Command } from './command-center.js';
@@ -55,6 +55,10 @@ export class LaunchpadCore {
 		this._commands.add(new Command({name: 'update-content', callback: this._runUpdateContent}));
 		
 		this._commands.addCommandHooks(this._config.hooks);
+		
+		if (this._config.shutdownOnExit) {
+			onExit(this.shutdown);
+		}
 	}
 	
 	/**

--- a/packages/launchpad/lib/launchpad-options.js
+++ b/packages/launchpad/lib/launchpad-options.js
@@ -18,8 +18,16 @@ export class LaunchpadOptions {
 		commands = new CommandOptions(),
 		hooks = new CommandHooks(),
 		logging = new LogOptions(),
+		shutdownOnExit = true,
 		...rest
 	} = {}) {
+		
+		/**
+		 * Will listen for exit events 
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.shutdownOnExit = true;
 		
 		/**
 		 * @type {ContentOptions}

--- a/packages/launchpad/test/test.js
+++ b/packages/launchpad/test/test.js
@@ -1,5 +1,5 @@
 import LaunchpadCore from '@bluecadet/launchpad';
-import { ConfigManager, launchFromCli } from '@bluecadet/launchpad-utils';
+import { ConfigManager, launchFromCli, onExit } from '@bluecadet/launchpad-utils';
 
 const getConfig = async (paths = ['user-config.js', 'config.js']) => {
 	return ConfigManager.importJsConfig(paths, import.meta);
@@ -17,17 +17,21 @@ launchFromCli(import.meta, {
 	
 	await launchpad.startup();
 	
-	const appNames = launchpad._monitor.getAllAppNames();
-	await Promise.all([...appNames, 'fake-app'].map(async (appName) => {
-		const isRunning = await launchpad._monitor.isRunning(appName);
-		console.debug(`App '${appName}' is running: ${isRunning}`);
-	}));
+	// const appNames = launchpad._monitor.getAllAppNames();
+	// await Promise.all([...appNames, 'fake-app'].map(async (appName) => {
+	// 	const isRunning = await launchpad._monitor.isRunning(appName);
+	// 	console.debug(`App '${appName}' is running: ${isRunning}`);
+	// }));
 	
-	await wait(10);
-	await launchpad.updateContent();
+	// onExit(async () => {
+	// 	await launchpad.shutdown();
+  // });
 	
-	await wait(10);
-	await launchpad.shutdown();
+	// await wait(10);
+	// await launchpad.updateContent();
+	
+	// await wait(10);
+	// await launchpad.shutdown();
 	
 }).catch(err => {
 	if (err) {

--- a/packages/monitor/lib/launchpad-monitor.js
+++ b/packages/monitor/lib/launchpad-monitor.js
@@ -121,8 +121,7 @@ export class LaunchpadMonitor {
 		}
 		
 		this._logger.info('Connecting to PM2');
-		await this._promisify(pm2.connect, pm2);
-		
+		await this._promisify(pm2.connect, pm2, true);
 		await this._connectPm2Bus();
 	}
 	

--- a/packages/utils/lib/log-manager.js
+++ b/packages/utils/lib/log-manager.js
@@ -180,6 +180,8 @@ class LogManager {
 				new winston.transports.DailyRotateFile({ ...this._config.fileOptions, filename: this.getFilePath('launchpad-error', false), level: 'error'}),
 			],
 		});
+
+		this.overrideConsoleMethods();
 	}
 	
 	/**
@@ -208,6 +210,25 @@ class LogManager {
 			output = path.join(this._config.fileOptions.dirname, output);
 		}
 		return output;
+	}
+
+
+	/**
+	 * Overrides console methods to use the parent logger instead
+	 * @private
+	 */
+	overrideConsoleMethods() {	
+		// Override console methods
+		const logger = this.getLogger();
+		console.log = logger.info.bind(logger);
+		console.info = logger.info.bind(logger);
+		console.warn = logger.warn.bind(logger);
+		console.error = logger.error.bind(logger);
+		console.debug = logger.debug.bind(logger);
+
+		// PM2 will try to override the console methods with it's own logger
+		// so we're freezing console here to prevent that from happening
+		Object.freeze(console);
 	}
 	
 }

--- a/packages/utils/lib/log-manager.js
+++ b/packages/utils/lib/log-manager.js
@@ -38,6 +38,7 @@ export class LogOptions {
 		fileOptions = new LogFileOptions(),
 		level = 'info',
 		format = LogOptions.DEFAULT_LOG_FORMAT,
+		overrideConsole = true,
 		...rest
 	} = {}) {
 		/**
@@ -67,6 +68,20 @@ export class LogOptions {
 		 * @default LogOptions.DEFAULT_LOG_FORMAT
 		 */
 		this.format = format;
+		
+		/**
+		 * Route all console logs to the log manager. This helps
+		 * ensure that logs are routed to files and rotated properly.
+		 * 
+		 * This will also freeze the console object, so it can't be
+		 * modified further during runtime.
+		 * 
+		 * All console logs will be prefixed with `(console)`.
+		 * 
+		 * @type {boolean}
+		 * @default true
+		 */
+		 this.overrideConsole = true;
 		
 		Object.assign(this, rest);
 	}
@@ -180,8 +195,10 @@ class LogManager {
 				new winston.transports.DailyRotateFile({ ...this._config.fileOptions, filename: this.getFilePath('launchpad-error', false), level: 'error'}),
 			],
 		});
-
-		this.overrideConsoleMethods();
+		
+		if (this._config.overrideConsole) {
+			this.overrideConsoleMethods();
+		}
 	}
 	
 	/**
@@ -219,7 +236,7 @@ class LogManager {
 	 */
 	overrideConsoleMethods() {	
 		// Override console methods
-		const logger = this.getLogger();
+		const logger = this.getLogger('console');
 		console.log = logger.info.bind(logger);
 		console.info = logger.info.bind(logger);
 		console.warn = logger.warn.bind(logger);


### PR DESCRIPTION
- connects to pm2 in `no-daemon-mode`
- overrides console methods to use parent logger
- freezes console methods so that pm2 can't override them

Those last two bullets are more of a temporary fix. A better, more permanent solution would be refactoring pm2 to allow for custom loggers instead of using console directly, perhaps by forking the pm2 repo or using [patch-package](https://www.npmjs.com/package/patch-package).

Tested with a handful of prod apps, everything seems to be working as expected.