### PR TITLE
Add support for JS configs

### DIFF
--- a/.changeset/chilled-eyes-kick.md
+++ b/.changeset/chilled-eyes-kick.md
@@ -1,0 +1,10 @@
+---
+"@bluecadet/launchpad-dashboard": minor
+"@bluecadet/launchpad": minor
+"@bluecadet/launchpad-scaffold": minor
+"@bluecadet/launchpad-content": minor
+"@bluecadet/launchpad-monitor": minor
+"@bluecadet/launchpad-utils": minor
+---
+
+support js configs

--- a/packages/launchpad/README.md
+++ b/packages/launchpad/README.md
@@ -31,7 +31,7 @@ graph LR
 ## Getting Started
 
 1. Install launchpad: `npm i @bluecadet/launchpad`
-2. Create a `launchpad.json` config (see [configuration](#configuration))
+2. Create a `launchpad.config.js` config (see [configuration](#configuration))
 3. *Optional: [Bootstrap](/packages/scaffold) your PC with `npx launchpad scaffold`*
 4. Run `npx launchpad`
 
@@ -43,10 +43,10 @@ Run `npx launchpad --help` to see all available commands.
 
 ## Configuration
 
-Each [launchpad package](#packages) is configured via its own section in `launchpad.json`. Below is a simple example that uses the [`content`](/packages/content) package to download JSON and images from Flickr and [`monitor`](/packages/monitor) to launch a single app:
+Each [launchpad package](#packages) is configured via its own section in `launchpad.config.js`. Below is a simple example that uses the [`content`](/packages/content) package to download JSON and images from Flickr and [`monitor`](/packages/monitor) to launch a single app:
 
-```json
-{
+```js
+export default {
   "content": {
     "sources": [
       {
@@ -91,7 +91,7 @@ All available config settings across packages can be found in the links below:
 
 ### Config Loading
 
-- By default, Launchpad looks for `launchpad.json` or `config.json` at the cwd (where you ran `npx launchpad`/`launchpad` from)
+- By default, Launchpad looks for `launchpad.config.js`, `launchpad.config.mjs`, `launchpad.json` or `config.json` at the cwd (where you ran `npx launchpad`/`launchpad` from)
 - You can change the default path with `--config=<YOUR_FILE_PATH>` (e.g. `npx launchpad --config=../settings/my-config.json`)
 - If no config is found, Launchpad will traverse up directories (up to 64) to find one
 - All config values can be overridden via `--foo=bar` (e.g. `--logging.level=debug`)

--- a/packages/utils/lib/config-manager.js
+++ b/packages/utils/lib/config-manager.js
@@ -6,19 +6,11 @@ import chalk from 'chalk';
 
 const DEFAULT_CONFIG_PATHS = ['launchpad.config.js', 'launchpad.config.mjs', 'launchpad.json', 'config.json'];
 
+/**
+ * @template T config type
+ */
 export class ConfigManager {
-	/** @type {ConfigManager | null} */
-	static _instance = null;
-	
-	/** @returns {ConfigManager} */
-	static getInstance() {
-		if (this._instance === null) {
-			this._instance = new ConfigManager();
-		}
-		return this._instance;
-	}
-	
-	/** @type {object} */
+	/** @type {Partial<T>} */
 	_config = {};
 	
 	/** @type {boolean} */
@@ -36,9 +28,10 @@ export class ConfigManager {
 	/**
 	 * Imports a JS config from a set of paths. The JS files have to export
 	 * its config as the default export. Will return the first config found.
+	 * @template T
 	 * @param {Array<string>} paths 
 	 * @param {ImportMeta?} importMeta The import.meta property of the file at your base directory.
-	 * @returns {Promise<object | null>} The parsed config object or null if none can be found
+	 * @returns {Promise<T | null>} The parsed config object or null if none can be found
 	 */
 	static async importJsConfig(paths, importMeta = null) {
 		const __dirname = ConfigManager.getProcessDirname(importMeta);
@@ -60,9 +53,9 @@ export class ConfigManager {
 	 * Loads the config in the following order of overrides:
 	 *   defaults < js/json < user 
 	 * 
-	 * @param {object?} userConfig Optional config overrides
+	 * @param {Partial<T>?} userConfig Optional config overrides
 	 * @param {string} [configPath] Optional path to a config file, relative to the current working directory.
- 	 * @returns {Promise<object>} A promise with the current config.
+ 	 * @returns {Promise<Partial<T>>} A promise with the current config.
 	 */
 	async loadConfig(userConfig = null, configPath) {
 		if (configPath) {
@@ -101,7 +94,7 @@ export class ConfigManager {
 	
 	/**
 	 * Retrieves the current config object.
-	 * @returns {object}
+	 * @returns {Partial<T>}
 	 */
 	getConfig() {
 		return this._config;
@@ -159,7 +152,9 @@ export class ConfigManager {
 	}
 	
 	/**
+	 * @template T
 	 * @param {string} configPath 
+	 * @returns {Promise<Partial<T>>}
 	 * @private
 	 */
 	static async _loadConfigFromFile(configPath) {

--- a/packages/utils/lib/config-manager.js
+++ b/packages/utils/lib/config-manager.js
@@ -71,7 +71,7 @@ export class ConfigManager {
 			// if no config is specified, search current and parent directories for default config files.
 			// Only the first found config will be loaded.
 			for (const defaultPath of DEFAULT_CONFIG_PATHS) {
-				const resolved = ConfigManager._fileExistsRecursive(defaultPath);
+				const resolved = ConfigManager._findFirstFileRecursive(defaultPath);
 				
 				if (resolved) {
 					console.warn(`Found config at '${chalk.white(resolved)}'`);
@@ -120,7 +120,7 @@ export class ConfigManager {
 	 * @returns {string | null} The absolute path to the file or null if it doesn't exist.
 	 * @private
 	 */
-	static _fileExistsRecursive(filePath) {
+	static _findFirstFileRecursive(filePath) {
 		const maxDepth = 64;
 
 		let absPath = filePath;

--- a/packages/utils/lib/launch-from-cli.js
+++ b/packages/utils/lib/launch-from-cli.js
@@ -32,7 +32,7 @@ export const launchFromCli = async (importMeta, {
 		return Promise.reject();
 	}
 	
-	ConfigManager.getInstance().loadConfig(userConfig, yargsCallback);
+	await ConfigManager.getInstance().loadConfig(userConfig, yargsCallback);
 	/** @type {any} TODO: figure out where to add this 'logging' property */
 	const config = ConfigManager.getInstance().getConfig();
 	LogManager.getInstance(config.logging || config);

--- a/packages/utils/lib/launch-from-cli.js
+++ b/packages/utils/lib/launch-from-cli.js
@@ -46,10 +46,12 @@ export const launchFromCli = async (importMeta, {
 	}
 
 	const parsedArgv = await argv.parse();
+
+	const configManager = new ConfigManager();
 	
-	await ConfigManager.getInstance().loadConfig(userConfig, parsedArgv.config);
+	await configManager.loadConfig(userConfig, parsedArgv.config);
 	/** @type {any} TODO: figure out where to add this 'logging' property */
-	const config = ConfigManager.getInstance().getConfig();
+	const config = configManager.getConfig();
 	LogManager.getInstance(config.logging || config);
 	
 	return Promise.resolve(config);

--- a/packages/utils/lib/launch-from-cli.js
+++ b/packages/utils/lib/launch-from-cli.js
@@ -49,7 +49,7 @@ export const launchFromCli = async (importMeta, {
 
 	const configManager = new ConfigManager();
 	
-	await configManager.loadConfig(userConfig, parsedArgv.config);
+	await configManager.loadConfig({ ...userConfig, ...parsedArgv }, parsedArgv.config);
 	/** @type {any} TODO: figure out where to add this 'logging' property */
 	const config = configManager.getConfig();
 	LogManager.getInstance(config.logging || config);

--- a/packages/utils/lib/launch-from-cli.js
+++ b/packages/utils/lib/launch-from-cli.js
@@ -2,6 +2,8 @@ import url from 'url';
 
 import ConfigManager from './config-manager.js';
 import LogManager from './log-manager.js';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 /**
  * Resolves with a promise including the current config if your
@@ -31,8 +33,21 @@ export const launchFromCli = async (importMeta, {
 		// eslint-disable-next-line prefer-promise-reject-errors
 		return Promise.reject();
 	}
+
+	let argv = yargs(hideBin(process.argv))
+		.parserConfiguration({
+		// See https://github.com/yargs/yargs-parser#camel-case-expansion
+			'camel-case-expansion': false
+		})
+		.option('config', { alias: 'c', describe: 'Path to your JS or JSON config file.', type: 'string' }).help();
+
+	if (yargsCallback) {
+		argv = yargsCallback(argv);
+	}
+
+	const parsedArgv = await argv.parse();
 	
-	await ConfigManager.getInstance().loadConfig(userConfig, yargsCallback);
+	await ConfigManager.getInstance().loadConfig(userConfig, parsedArgv.config);
 	/** @type {any} TODO: figure out where to add this 'logging' property */
 	const config = ConfigManager.getInstance().getConfig();
 	LogManager.getInstance(config.logging || config);


### PR DESCRIPTION
fixes #70

- adjusted ConfigManager to allow loading of js configs
- made the CLI `--config` flag compatible with js configs
- slightly adjusted the config loading procedure:
   - only load first found config if no config is passed via CLI args
   - fatally errors our if it is unable to load first config
- added `launchpad.config.js` and `launchpad.config.mjs` as default config files and prioritized them when searching
- added deprecation warning when using JSON configs

Tested on a couple projects, and this seems to work! Importing from other files in the js config works too. I'm breaking config intellisense out into another issue.

I also adjusted the config loading procedure, as I think it makes more sense to fail rather than keep searching for valid configs when a broken config is found.

ref #65