### PR TITLE
config intellisense

### DIFF
--- a/.changeset/chatty-mirrors-smash.md
+++ b/.changeset/chatty-mirrors-smash.md
@@ -1,0 +1,8 @@
+---
+"@bluecadet/launchpad": minor
+"@bluecadet/launchpad-content": minor
+"@bluecadet/launchpad-monitor": minor
+"@bluecadet/launchpad-utils": minor
+---
+
+Add intellisense support to configs

--- a/.changeset/chilled-eyes-kick.md
+++ b/.changeset/chilled-eyes-kick.md
@@ -1,0 +1,10 @@
+---
+"@bluecadet/launchpad-dashboard": minor
+"@bluecadet/launchpad": minor
+"@bluecadet/launchpad-scaffold": minor
+"@bluecadet/launchpad-content": minor
+"@bluecadet/launchpad-monitor": minor
+"@bluecadet/launchpad-utils": minor
+---
+
+support js configs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,5 @@ npm link
 
 cd ../../my-test-project
 @REM If needed: npm init
-npm link @bluecadet/launchpad
-@REM  If needed for your project: npm i @bluecadet/launchpad
+npm link @bluecadet/launchpad --save
 ```

--- a/packages/content/lib/content-options.js
+++ b/packages/content/lib/content-options.js
@@ -66,3 +66,18 @@ export const CONTENT_OPTION_DEFAULTS = {
 	ignoreImageTransformErrors: true,
 	forceClearTempFiles: true
 };
+
+/**
+ * Apply defaults to passed content config
+ * @param {ContentOptions} [config]
+ */
+export function resolveContentOptions(config) {
+	return {
+		...CONTENT_OPTION_DEFAULTS,
+		...config
+	};
+}
+
+/**
+ * @typedef {ReturnType<typeof resolveContentOptions>} ContentOptionsResolved
+ */

--- a/packages/content/lib/content-options.js
+++ b/packages/content/lib/content-options.js
@@ -2,197 +2,67 @@
  * @module launchpad-content/content-options
  */
 
-import { SourceOptions } from './content-sources/content-source.js';
+export const DOWNLOAD_PATH_TOKEN = '%DOWNLOAD_PATH%';
+
+export const TIMESTAMP_TOKEN = '%TIMESTAMP%';
 
 /**
- * Options for all content and media downloads. Each of these settings can also be configured per `ContentSource`.
+ * @typedef { import('./content-sources/airtable-source.js').AirtableOptions 
+ *  | import('./content-sources/contentful-source.js').ContentfulOptions
+ *  | import('./content-sources/json-source.js').JsonOptions
+ *  | import('./content-sources/sanity-source.js').SanityOptions
+ *  | import('./content-sources/strapi-source.js').StrapiOptions
+ * } AllSourceOptions
  */
-export class ContentOptions {
-	static get DOWNLOAD_PATH_TOKEN() {
-		return '%DOWNLOAD_PATH%';
-	}
-	
-	static get TIMESTAMP_TOKEN() {
-		return '%TIMESTAMP%';
-	}
-	
-	/**
-	 * @param {any} options
-	 */
-	constructor({
-		sources = [],
-		imageTransforms = [],
-		contentTransforms = {},
-		downloadPath = '.downloads/',
-		credentialsPath = '.credentials.json',
-		tempPath = `${ContentOptions.DOWNLOAD_PATH_TOKEN}/.tmp/`,
-		backupPath = `${ContentOptions.DOWNLOAD_PATH_TOKEN}/.tmp-backup/`,
-		keep = '',
-		strip = '',
-		backupAndRestore = true,
-		maxConcurrent = 4,
-		maxTimeout = 30000,
-		clearOldFilesOnStart = false,
-		clearOldFilesOnSuccess = true,
-		ignoreCache = false,
-		enableIfModifiedSinceCheck = true,
-		enableContentLengthCheck = true,
-		abortOnError = true,
-		ignoreImageTransformErrors = true,
-		ignoreImageTransformCache = false,
-		forceClearTempFiles = true,
-		...rest // Any additional custom arguments
-	} = {}) {
-		/**
-		 * A list of content source options. This defines which content is downloaded from where.
-		 * @type {Array<SourceOptions>}
-		 * @default []
-		 */
-		this.sources = sources;
-		
-		/**
-		 * A list of image transforms to apply to a copy of each downloaded image.
-		 * @type {Array<Object<string, number>>}
-		 * @default []
-		 */
-		this.imageTransforms = imageTransforms;
-		
-		/**
-		 * A list of content transforms to apply to all donwloaded content.
-		 * @type {Object<string, string>}
-		 * @default {}
-		 */
-		this.contentTransforms = contentTransforms;
-		
-		/**
-		 * The path at which to store all downloaded files.
-		 * @type {string}
-		 * @default '.downloads/'
-		 */
-		this.downloadPath = downloadPath;
-		
-		/**
-		 * The path to the json containing credentials for all content sources.
-		 * @type {string}
-		 * @default '.credentials.json'
-		 */
-		this.credentialsPath = credentialsPath;
-		
-		/**
-		 * Temp file directory path.
-		 * @type {string}
-		 * @default '%DOWNLOAD_PATH%/.tmp/'
-		 */
-		this.tempPath = tempPath;
-		
-		/**
-		 * Temp directory path where all downloaded content will be backed up before removal.
-		 * @type {string}
-		 * @default '%DOWNLOAD_PATH%/.backups/'
-		 */
-		this.backupPath = backupPath;
-		
-		/**
-		 * Which files to keep in `dest` if `clearOldFilesOnSuccess` or `clearOldFilesOnStart` are `true`. E.g. `'*.json|*.csv|*.xml|*.git*'`
-		 * @type {string}
-		 * @default ''
-		 */
-		this.keep = keep;
-		
-		/**
-		 * Strips this string from all media file paths when saving them locally
-		 * @type {string}
-		 * @default ''
-		 */
-		this.strip = strip;
-		
-		/**
-		 * Back up files before downloading and restore originals for all sources on failure of any single source.
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.backupAndRestore = backupAndRestore;
-		
-		/**
-		 * Max concurrent downloads.
-		 * @type {number}
-		 * @default 4
-		 */
-		this.maxConcurrent = maxConcurrent;
-		
-		/**
-		 * Max request timeout in ms.
-		 * @type {number}
-		 * @default 30000
-		 */
-		this.maxTimeout = maxTimeout;
-		
-		/**
-		 * Remove all existing files in dest dir when downloads succeed. Ignores files that match `keep`
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.clearOldFilesOnSuccess = clearOldFilesOnSuccess;
-		
-		/**
-		 * Will remove all existing files _before_ downloads starts. `false` will ensure that existing files are only deleted after a download succeeds.
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.clearOldFilesOnStart = clearOldFilesOnStart;
-		
-		/**
-		 * Will always download files regardless of whether they've been cached
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.ignoreCache = ignoreCache;
-		
-		/**
-		 * Enables the HTTP if-modified-since check. Disabling this will assume that the local file is the same as the remote file if it already exists.
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.enableIfModifiedSinceCheck = enableIfModifiedSinceCheck;
-		
-		/**
-		 * Compares the HTTP header content-length with the local file size. Disabling this will assume that the local file is the same as the remote file if it already exists.
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.enableContentLengthCheck = enableContentLengthCheck;
-		
-		/**
-		 * If set to `true`, errors will cause syncing to abort all remaining tasks immediately
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.abortOnError = abortOnError;
-		
-		/** 
-		 * Set to `true` to always re-generate transformed images, even if cached versions of the original and transformed image already exist.
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.ignoreImageTransformCache = ignoreImageTransformCache;
-		
-		/** 
-		 * Set to `false` if you want to abort a content source from downloading if any of the image transforms fail. Leaving this to `true` will allow for non-image files to fail quietly.
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.ignoreImageTransformErrors = ignoreImageTransformErrors;
-		
-		/**
-		 * Set to `false` if you want to keep all contents of the tempPath dir before downloading
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.forceClearTempFiles = forceClearTempFiles;
-		
-		// Allows for additional properties to be inherited
-		Object.assign(this, rest);
-	}
-}
 
-export default ContentOptions;
+/**
+ * @typedef ContentOptions
+ * @property {AllSourceOptions[] | Record<string, AllSourceOptions>} [sources] A list of content source options. This defines which content is downloaded from where.
+ * @property {Array<Object<string, number>>} [imageTransforms] A list of image transforms to apply to a copy of each downloaded image.
+ * @property {Object<string, string>} [contentTransforms] A list of content transforms to apply to all donwloaded content.
+ * @property {string} [downloadPath] The path at which to store all downloaded files. Defaults to '.downloads/'.
+ * @property {string} [credentialsPath] The path to the json containing credentials for all content sources. Defaults to '.credentials.json'.
+ * @property {string} [tempPath] Temp file directory path. Defaults to '%DOWNLOAD_PATH%/.tmp/'.
+ * @property {string} [backupPath] Temp directory path where all downloaded content will be backed up before removal. Defaults to '%TIMESTAMP%/.tmp-backup/'.
+ * @property {string} [keep] Which files to keep in `dest` if `clearOldFilesOnSuccess` or `clearOldFilesOnStart` are `true`. E.g. `'*.json|*.csv|*.xml|*.git*'`
+ * @property {string} [strip] Strips this string from all media file paths when saving them locally
+ * @property {boolean} [backupAndRestore] Back up files before downloading and restore originals for all sources on failure of any single source. Defaults to true.
+ * @property {number} [maxConcurrent] Max concurrent downloads. Defaults to 4.
+ * @property {number} [maxTimeout] Max request timeout in ms. Defaults to 30000.
+ * @property {boolean} [clearOldFilesOnSuccess] Remove all existing files in dest dir when downloads succeed. Ignores files that match `keep`. Defaults to true.
+ * @property {boolean} [clearOldFilesOnStart] Will remove all existing files _before_ downloads starts. `false` will ensure that existing files are only deleted after a download succeeds. Defaults to false.
+ * @property {boolean} [ignoreCache] Will always download files regardless of whether they've been cached. Defaults to false.
+ * @property {boolean} [enableIfModifiedSinceCheck] Enables the HTTP if-modified-since check. Disabling this will assume that the local file is the same as the remote file if it already exists. Defaults to true.
+ * @property {boolean} [enableContentLengthCheck] Compares the HTTP header content-length with the local file size. Disabling this will assume that the local file is the same as the remote file if it already exists. Defaults to true.
+ * @property {boolean} [abortOnError] If set to `true`, errors will cause syncing to abort all remaining tasks immediately. Defaults to true.
+ * @property {boolean} [ignoreImageTransformCache] Set to `true` to always re-generate transformed images, even if cached versions of the original and transformed image already exist. Defaults to false.
+ * @property {boolean} [ignoreImageTransformErrors] Set to `false` if you want to abort a content source from downloading if any of the image transforms fail. Leaving this to `true` will allow for non-image files to fail quietly. Defaults to true.
+ * @property {boolean} [forceClearTempFiles] Set to `false` if you want to keep all contents of the tempPath dir before downloading. Defaults to true.
+ */
+
+/**
+ * @type {Required<ContentOptions>}
+ */
+export const CONTENT_OPTION_DEFAULTS = {
+	sources: [],
+	imageTransforms: [],
+	contentTransforms: {},
+	downloadPath: '.downloads/',
+	credentialsPath: '.credentials.json',
+	tempPath: '%DOWNLOAD_PATH%/.tmp/',
+	backupPath: '%TIMESTAMP%/.tmp-backup/',
+	keep: '',
+	strip: '',
+	backupAndRestore: true,
+	maxConcurrent: 4,
+	maxTimeout: 30000,
+	clearOldFilesOnSuccess: true,
+	clearOldFilesOnStart: false,
+	ignoreCache: false,
+	enableIfModifiedSinceCheck: true,
+	enableContentLengthCheck: true,
+	abortOnError: true,
+	ignoreImageTransformCache: false,
+	ignoreImageTransformErrors: true,
+	forceClearTempFiles: true
+};

--- a/packages/content/lib/content-options.js
+++ b/packages/content/lib/content-options.js
@@ -17,7 +17,7 @@ export const TIMESTAMP_TOKEN = '%TIMESTAMP%';
 
 /**
  * @typedef ContentOptions
- * @property {AllSourceOptions[] | Record<string, AllSourceOptions>} [sources] A list of content source options. This defines which content is downloaded from where.
+ * @property {AllSourceOptions[]} [sources] A list of content source options. This defines which content is downloaded from where.
  * @property {Array<Object<string, number>>} [imageTransforms] A list of image transforms to apply to a copy of each downloaded image.
  * @property {Object<string, string>} [contentTransforms] A list of content transforms to apply to all donwloaded content.
  * @property {string} [downloadPath] The path at which to store all downloaded files. Defaults to '.downloads/'.
@@ -79,5 +79,13 @@ export function resolveContentOptions(config) {
 }
 
 /**
- * @typedef {ReturnType<typeof resolveContentOptions>} ContentOptionsResolved
+ * @typedef {ReturnType<typeof resolveContentOptions>} ResolvedContentOptions
  */
+
+/**
+ * @param {ContentOptions} config 
+ * @returns {ContentOptions}
+ */
+export function defineContentConfig(config) {
+	return config;
+}

--- a/packages/content/lib/content-sources/content-result.js
+++ b/packages/content/lib/content-sources/content-result.js
@@ -6,14 +6,14 @@ export class DataFile {
 	localPath = '';
 	/**
 	 * The file contents to be saved.
-	 * @type {*}
+	 * @type {unknown}
 	 */
 	content = '';
 
 	/**
 	 *
 	 * @param {string} localPath
-	 * @param {string|JSON|object|Array<any>} content
+	 * @param {unknown} content
 	 */
 	constructor(localPath, content) {
 		this.localPath = localPath;
@@ -25,7 +25,7 @@ export class DataFile {
 	 * @returns {string}
 	 */
 	getContentStr() {
-		if ((typeof this.content) === 'string') {
+		if (typeof this.content === 'string') {
 			return this.content;
 		} else if (this.content) {
 			return JSON.stringify(this.content);
@@ -109,7 +109,7 @@ export class ContentResult {
 	/**
 	 *
 	 * @param {string} localPath
-	 * @param {*} content
+	 * @param {unknown} content
 	 */
 	addDataFile(localPath, content) {
 		this.dataFiles.push(new DataFile(localPath, content));
@@ -156,6 +156,11 @@ export class ContentResult {
 
 		// Collect all data into 1 object.
 		const collatedData = this.dataFiles.reduce((previousValue, currentValue) => {
+			// error if the content isn't iterable
+			if (!Array.isArray(currentValue.content)) {
+				throw new Error(`Content for ${currentValue.localPath} is not iterable`);
+			}
+
 			return [...previousValue, ...currentValue.content];
 		}, initial);
 

--- a/packages/content/lib/content-sources/content-source.js
+++ b/packages/content/lib/content-sources/content-source.js
@@ -3,43 +3,30 @@
  */
 
 import chalk from 'chalk';
-import fs from 'fs-extra';
 import { Logger } from '@bluecadet/launchpad-utils';
 import ContentResult from './content-result.js';
 
-/**
- * Base class for all content sources. `id` is mandatory.
- */
-export class SourceOptions {
-	static get IMAGE_REGEX() {
-		return /.+(\.jpg|\.jpeg|\.png)/gi;
-	}
-	
-	static get VIDEO_REGEX() {
-		return /.+(\.avi|\.mov|\.mp4|\.mpg|\.mpeg)/gi;
-	}
-	
-	static get MEDIA_REGEX() {
-		return new RegExp(`(${SourceOptions.IMAGE_REGEX.source})|(${SourceOptions.VIDEO_REGEX.source})`);
-	}
-	
-	constructor({
-		id = '',
-		...rest
-	} = {}) {
-		/**
-		 * Required field to identify this source. Will be used as download path.
-		 * @type {string}
-		 */
-		this.id = id;
-		
-		// Allows for additional properties to be inherited
-		Object.assign(this, rest);
-	}
-}
+export const IMAGE_REGEX = /.+(\.jpg|\.jpeg|\.png)/gi;
+export const VIDEO_REGEX = /.+(\.avi|\.mov|\.mp4|\.mpg|\.mpeg)/gi;
+export const MEDIA_REGEX = new RegExp(`(${IMAGE_REGEX.source})|(${VIDEO_REGEX.source})`);
 
 /**
- * @template {SourceOptions} [C=SourceOptions]
+ * @template T
+ * @typedef {Required<{[K in keyof T as  T extends Record<K, T[K]> ? never : K]: T[K]}>} SelectOptional Select only the optional properties of a type.
+ * @example
+ * type Foo = { a: string, b?: number };
+ * type OptionalFoo = SelectOptional<Foo>; // { b: number }
+ */
+
+/**
+ * @template {string} T
+ * @typedef SourceOptions
+ * @property {string} id Required field to identify this source. Will be used as download path.
+ * @property {T} type The type of content source. Used internally to determine which source class to use.
+ */
+
+/**
+ * @template {SourceOptions<string>} [C=SourceOptions<string>]
  */
 export class ContentSource {
 	/** @type {C} */

--- a/packages/content/lib/content-sources/contentful-source.js
+++ b/packages/content/lib/content-sources/contentful-source.js
@@ -3,137 +3,88 @@
  */
 
 import contentful from 'contentful';
-import ContentSource, { SourceOptions } from './content-source.js';
+import ContentSource from './content-source.js';
 import ContentResult, { MediaDownload } from './content-result.js';
 import Credentials from '../credentials.js';
 import { Logger } from '@bluecadet/launchpad-utils';
 
 /**
- * Configuration options for the Contentful ContentSource.
- * 
- * Also supports all fields of the Contentful SDK's config.
- * 
- * @see Configuration under https://contentful.github.io/contentful.js/contentful/9.1.7/
+ * @typedef ContentfulCredentialsAccessToken
+ * @property {string} accessToken LEGACY: For backwards compatibility you can only set the `"accessToken"` using your delivery or preview token and a combination of the usePreviewApi flag.
  */
-export class ContentfulOptions extends SourceOptions {
-	/**
-	 * @param {any} options
-	 */
-	constructor({
-		space = '',
-		locale = 'en-US',
-		filename = 'content.json',
-		protocol = 'https',
-		host = 'cdn.contentful.com',
-		usePreviewApi = false,
-		contentTypes = [],
-		searchParams = {
-			limit: 1000, // This is the max that Contentful supports,
-			include: 10 // @see https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/links/retrieval-of-linked-items
-		},
-		imageParams = {},
-		accessToken = '',
-		deliveryToken = '',
-		previewToken = '',
-		...rest
-	} = {}) {
-		super(rest);
-		
-		/**
-		 * Your Contentful space ID. Note that credentials.json will require an accessToken in addition to this
-		 * @type {string}
-		 * @default ''
-		 */
-		this.space = space;
-		
-		/**
-		 * Optional. Used to pull localized images.
-		 * @type {string}
-		 * @default 'en-US'
-		 */
-		this.locale = locale;
-		
-		/**
-		 * Optional. The filename you want to use for where all content (entries and assets metadata) will be stored.
-		 * @type {string}
-		 * @default 'content.json'
-		 */
-		this.filename = filename;
-		
-		/**
-		 * Optionally limit queries to these content types.
-		 * This will also apply to linked assets.
-		 * Types that link to other types will include up to 10 levels of child content.
-		 * E.g. filtering by Story, might also include Chapters and Images.
-		 * Uses `searchParams['sys.contentType.sys.id[in]']` under the hood.
-		 * @type {Array<string>}
-		 */
-		this.contentTypes = contentTypes;
-		
-		/**
-		 * Optional. Supports anything from https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters
-		 * @type {Object}
-		 */
-		this.searchParams = searchParams;
-		
-		/**
-		 * Optional. Applies to all images. Defaults to empty object.
-		 * **IMPORTANT:** If you change the parameters, you will have to delete all cached images since the modified date of the original image will not have changed.
-		 * @see https://www.contentful.com/developers/docs/references/images-api/#/reference/resizing-&-cropping/specify-focus-area
-		 * @type {Object}
-		 */
-		this.imageParams = imageParams;
-		
-		/**
-		 * Optional
-		 * @type {string}
-		 * @default 'https'
-		 */
-		this.protocol = protocol;
-		
-		/**
-		 * Optional
-		 * @type {string}
-		 * @default 'cdn.contentful.com'
-		 */
-		this.host = host;
-		
-		/**
-		 * Optional. Set to true if you want to use the preview API instead of the production version to view draft content.
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.usePreviewApi = usePreviewApi;
-		
-		/**
-		 * Content delivery token (all published content).
-		 * @type {string}
-		 */
-		this.deliveryToken = deliveryToken;
-		
-		/**
-		 * Content preview token (only unpublished/draft content).
-		 * @type {string}
-		 */
-		this.previewToken = previewToken;
-		
-		/**
-		 * LEGACY: For backwards compatibility you can only set the `"accessToken"` using your delivery or preview token and a combination of the usePreviewApi flag.
-		 * @type {string}
-		 */
-		this.accessToken = accessToken;
-	}
-}
 
 /**
- * @extends {ContentSource<ContentfulOptions>}
+ * @typedef ContentfulCredentialsDeliveryToken
+ * @property {string} deliveryToken Content delivery token (all published content).
+ * @property {string} [previewToken] Content preview token (only unpublished/draft content).
+ */
+
+/**
+ * @typedef ContentfulCredentialsPreviewToken
+ * @property {string} previewToken Content preview token (only unpublished/draft content).
+ */
+
+/**
+ * @typedef {ContentfulCredentialsAccessToken | ContentfulCredentialsDeliveryToken | ContentfulCredentialsPreviewToken} ContentfulCredentials
+ */
+
+/**
+ * @typedef BaseContentfulOptions
+ * @property {string} space Your Contentful space ID. Note that credentials.json will require an accessToken in addition to this
+ * @property {string} [locale] Optional. Used to pull localized images.
+ * @property {string} [filename] Optional. The filename you want to use for where all content (entries and assets metadata) will be stored. Defaults to 'content.json'
+ * @property {string} [protocol] Optional. Defaults to 'https'
+ * @property {string} [host] Optional. Defaults to 'cdn.contentful.com'
+ * @property {boolean} [usePreviewApi] Optional. Set to true if you want to use the preview API instead of the production version to view draft content. Defaults to false
+ * @property {Array<string>} [contentTypes] Optionally limit queries to these content types. This will also apply to linked assets. Types that link to other types will include up to 10 levels of child content. E.g. filtering by Story, might also include Chapters and Images. Uses `searchParams['sys.contentType.sys.id[in]']` under the hood.
+ * @property {any} [searchParams] Optional. Supports anything from https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters
+ * @property {any} [imageParams] Optional. Applies to all images. Defaults to empty object. **IMPORTANT:** If you change the parameters, you will have to delete all cached images since the modified date of the original image will not have changed.
+ */
+
+/**
+ * @typedef {Omit<import('contentful').CreateClientParams, keyof BaseContentfulOptions | 'accessToken'>} ContentfulClientParams
+ */
+
+/**
+ * Configuration options for the Contentful ContentSource.
+ *
+ * Also supports all fields of the Contentful SDK's config.
+ *
+ * @see Configuration under https://contentful.github.io/contentful.js/contentful/9.1.7/
+ * 
+ * @typedef {import('./content-source.js').SourceOptions<'contentful'> & BaseContentfulOptions & ContentfulClientParams & (ContentfulCredentials | {})} ContentfulOptions
+ */
+
+/**
+ * @typedef {import('./content-source.js').SourceOptions<'contentful'> & Required<BaseContentfulOptions> & ContentfulClientParams & {accessToken: string}} ContentfulOptionsAssembled
+ */
+
+/** 
+ * @satisfies {Partial<BaseContentfulOptions>} 
+ */
+const CONTENTFUL_OPTIONS_DEFAULTS = {
+	locale: 'en-US',
+	filename: 'content.json',
+	protocol: 'https',
+	host: 'cdn.contentful.com',
+	usePreviewApi: false,
+	contentTypes: [],
+	searchParams: {
+		limit: 1000, // This is the max that Contentful supports,
+		include: 10 // @see https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/links/retrieval-of-linked-items
+	},
+	imageParams: {}
+};
+
+/**
+ * @extends {ContentSource<ContentfulOptionsAssembled>}
  */
 class ContentfulSource extends ContentSource {
 	/** @type {contentful.ContentfulClientApi} */
 	client;
 
 	/**
-	 * @param {*} config 
+	 * @param {ContentfulOptions} config 
 	 * @param {Logger} logger 
 	 */
 	constructor(config, logger) {
@@ -278,28 +229,81 @@ class ContentfulSource extends ContentSource {
 	}
 
 	/**
-	 * @param {any} config
+	 * @param {ContentfulOptions} config
+	 * @returns {ContentfulOptionsAssembled}
 	 */
 	static _assembleConfig(config) {
-		config = new ContentfulOptions({
-			...config,
-			...Credentials.getCredentials(config.id)
-		});
-		
-		if (config.usePreviewApi || (!config.accessToken && !config.deliveryToken && config.previewToken)) {
-			config.host = 'preview.contentful.com';
-			config.usePreviewApi = true;
-		}
-		
-		if (!config.accessToken) {
-			config.accessToken = config.usePreviewApi ? config.previewToken : config.deliveryToken;
+		const creds = Credentials.getCredentials(config.id);
+
+		/**
+		 * @type {ContentfulCredentials}
+		 */
+		let validatedCredentials;
+
+		if (creds) {
+			if (!ContentfulSource._validateCrendentials(creds)) {
+				throw new Error(`Contentful credentials for '${config.id}' are invalid`);
+			}
+
+			validatedCredentials = creds;
+		} else {
+			if (!ContentfulSource._validateCrendentials(config)) {
+				throw new Error(`No Contentful credentials found for '${config.id}' in credentials file or launchpad config.`);
+			}
+
+			validatedCredentials = config;
 		}
 
-		if (config.contentTypes && config.contentTypes.length > 0) {
-			config.searchParams['sys.contentType.sys.id[in]'] = config.contentTypes.join(',');
+		const assembled = {
+			accessToken: '',
+			...CONTENTFUL_OPTIONS_DEFAULTS,
+			...config
+		};
+		
+		if (!('deliveryToken' in validatedCredentials) && 'previewToken' in validatedCredentials) {
+			// if we only have a preview token, use the preview API
+			assembled.usePreviewApi = true;
 		}
 
-		return config;
+		if (assembled.usePreviewApi) {
+			assembled.host = 'preview.contentful.com';
+		}
+		
+		if ('accessToken' in validatedCredentials) {
+			// if access token is set, use it
+			assembled.accessToken = validatedCredentials.accessToken;
+		} else if (assembled.usePreviewApi) {
+			// if usePreviewApi is true, use previewToken
+			if (!('previewToken' in validatedCredentials) || !validatedCredentials.previewToken) {
+				throw new Error(`usePreviewApi is set to true, but no previewToken is provided for '${config.id}'`);
+			}
+			assembled.accessToken = validatedCredentials.previewToken;
+		} else {
+			// otherwise just use deliveryToken
+			if (!('deliveryToken' in validatedCredentials) || !validatedCredentials.deliveryToken) {
+				throw new Error(`no deliveryToken is provided for '${config.id}'`);
+			}
+			assembled.accessToken = validatedCredentials.deliveryToken;
+		}
+
+		if (assembled.contentTypes && assembled.contentTypes.length > 0) {
+			assembled.searchParams['sys.contentType.sys.id[in]'] = assembled.contentTypes.join(',');
+		}
+
+		return assembled;
+	}
+
+	/**
+	 * @private
+	 * @param {unknown} creds 
+	 * @returns {creds is ContentfulCredentials}
+	 */
+	static _validateCrendentials(creds) {
+		if (typeof creds !== 'object' || creds === null) {
+			return false;
+		}
+
+		return 'accessToken' in creds || 'deliveryToken' in creds || 'previewToken' in creds;
 	}
 }
 

--- a/packages/content/lib/content-sources/json-source.js
+++ b/packages/content/lib/content-sources/json-source.js
@@ -3,53 +3,41 @@
  */
 
 import JsonUtils from '../utils/json-utils.js';
-import ContentSource, { SourceOptions } from './content-source.js';
+import ContentSource, { MEDIA_REGEX } from './content-source.js';
 import ContentResult, { MediaDownload } from './content-result.js';
 import got from 'got';
 import { Logger } from '@bluecadet/launchpad-utils';
 import chalk from 'chalk';
 
 /**
- * @class
+ * @typedef BaseJsonOptions
+ * @property {RegExp} [mediaPattern] Regex for media files that should be downloaded from json sources. Defaults to `/.+(\.jpg|\.jpeg|\.png)/gi|/.+(\.avi|\.mov|\.mp4|\.mpg|\.mpeg)/gi`
+ * @property {Record<string, string>} files A mapping of json file-path -> url
  */
-export class JsonOptions extends SourceOptions {
-	/**
-	 * @param {any} options
-	 */
-	constructor({
-		mediaPattern = SourceOptions.MEDIA_REGEX,
-		files = {},
-		...rest
-	} = {}) {
-		super(rest);
-		
-		/**
-		 * Regex for media files that should be downloaded from json sources
-		 * @type {RegExp}
-		 * @default (/.+(\.jpg|\.jpeg|\.png)/gi|/.+(\.avi|\.mov|\.mp4|\.mpg|\.mpeg)/gi)
-		 */
-		this.mediaPattern = new RegExp(mediaPattern);
-		
-		/**
-		 * A mapping of json file-path -> url
-		 * @type {Object<string,string>}
-		 * @default {}
-		 */
-		this.files = files;
-	}
-}
 
 /**
- * @extends {ContentSource<JsonOptions>}
+ * @typedef {import('./content-source.js').SourceOptions<'json'> & BaseJsonOptions} JsonOptions
+ */
+
+/**
+ * @typedef {import('./content-source.js').SourceOptions<'json'> & Required<BaseJsonOptions>} JsonOptionsAssembled
+ */
+
+const JSON_OPTIONS_DEFAULTS = {
+	mediaPattern: MEDIA_REGEX
+};
+
+/**
+ * @extends {ContentSource<JsonOptionsAssembled>}
  */
 class JsonSource extends ContentSource {
 	/**
 	 * 
-	 * @param {*} config 
+	 * @param {JsonOptions} config 
 	 * @param {Logger} logger 
 	 */
 	constructor(config, logger) {
-		super(new JsonOptions(config), logger);
+		super({ ...JSON_OPTIONS_DEFAULTS, ...config }, logger);
 	}
 	
 	/**

--- a/packages/content/lib/content-sources/strapi-source.js
+++ b/packages/content/lib/content-sources/strapi-source.js
@@ -7,106 +7,63 @@ import jsonpath from 'jsonpath';
 import got from 'got';
 import qs from 'qs';
 
-import ContentSource, { SourceOptions } from './content-source.js';
+import ContentSource from './content-source.js';
 import ContentResult, { MediaDownload } from './content-result.js';
 import Credentials from '../credentials.js';
 import { Logger } from '@bluecadet/launchpad-utils';
 
 /**
- * @typedef {Object} StrapiObjectQuery
+ * @typedef StrapiObjectQuery
  * @property {string} contentType The content type to query
  * @property {{pagination?: {page: number, pageSize: number}, [key: string]: unknown}} params Query parameters. Uses `qs` library to stringify.
  */
 
 /**
- * Options for StrapiSource
- */
-export class StrapiOptions extends SourceOptions {
-	/**
-	 * @param {any} options
-	 */
-	constructor({
-		version = '3',
-		baseUrl = undefined,
-		queries = [],
-		limit = 100,
-		maxNumPages = -1,
-		pageNumZeroPad = 0,
-		identifier = undefined,
-		password = undefined,
-		token = undefined,
-		...rest
-	} = {}) {
-		super(rest);
-		
-		/**
-		 * Versions `3` and `4` are supported.
-		 * @type {'3'|'4'}
-		 * @default '3'
-		 */
-		this.version = version;
-		
-		/**
-		 * The base url of your Strapi CMS (with or without trailing slash).
-		 * @type {string}
-		 */
-		this.baseUrl = baseUrl;
-		
-		/**
-		 * Queries for each type of content you want to save. One per content type. Content will be stored  as numbered, paginated JSONs.
-		 * You can include all query parameters supported by Strapi.
-		 * You can also pass an object with a `contentType` and `params` property, where `params` is an object of query parameters.
-		 * @type {Array.<string | StrapiObjectQuery>}
-		 * @default []
-		 */
-		this.queries = queries;
-		
-		/**
-		 * Max number of entries per page.
-		 * @type {number}
-		 * @default 100
-		 */
-		this.limit = limit;
-		
-		/**
-		 * Max number of pages. Use the default of `-1` for all pages
-		 * @type {number}
-		 * @default -1
-		 */
-		this.maxNumPages = maxNumPages;
-		
-		/**
-		 * How many zeros to pad each json filename index with.
-		 * @type {number}
-		 * @default 0
-		 */
-		this.pageNumZeroPad = pageNumZeroPad;
-		
-		/**
-		 * Username or email. Should be configured via `./credentials.json`
-		 * @type {string}
-		 */
-		this.identifier = identifier;
-		
-		/**
-		 * Should be configured via `./credentials.json`
-		 * @type {string}
-		 */
-		this.password = password;
-		
-		/**
-		 * Can be used instead of identifer/password if you previously generated one. Otherwise this will be automatically generated using the identifier or password.
-		 * @type {string}
-		 */
-		this.token = token;
-	}
-}
-
-/**
- * @typedef {Object} StrapiPagination
+ * @typedef StrapiPagination
  * @property {number} start The index of the first item to fetch
  * @property {number} limit The number of items to fetch
  */
+
+/** 
+ * @typedef StrapiLoginCredentials
+ * @property {string} identifier Username or email. Should be configured via `./credentials.json`
+ * @property {string} password Should be configured via `./credentials.json`
+ *
+ * @typedef StrapiTokenCredentials
+ * @property {string} token Can be used instead of identifer/password if you previously generated one. Otherwise this will be automatically generated using the identifier or password.
+ *
+ * @typedef {StrapiLoginCredentials | StrapiTokenCredentials} StrapiCredentials
+ */
+
+/**
+ * @typedef BaseStrapiOptions
+ * @property {'4' | '3'} [version] Versions `3` and `4` are supported. Defaults to `3`.
+ * @property {string} baseUrl The base url of your Strapi CMS (with or without trailing slash).
+ * @property {Array<string | StrapiObjectQuery>} queries Queries for each type of content you want to save. One per content type. Content will be stored as numbered, paginated JSONs.
+ * You can include all query parameters supported by Strapi.
+ * You can also pass an object with a `contentType` and `params` property, where `params` is an object of query parameters.
+ * @property {number} [limit] Max number of entries per page. Defaults to `100`.
+ * @property {number} [maxNumPages] Max number of pages. Use the default of `-1` for all pages. Defaults to `-1`.
+ * @property {number} [pageNumZeroPad] How many zeros to pad each json filename index with. Defaults to `0`.
+ */
+
+/**
+ * @typedef {import('./content-source.js').SourceOptions<'strapi'> & BaseStrapiOptions & (StrapiCredentials | {})} StrapiOptions
+ */
+
+/**
+ * @typedef {import('./content-source.js').SourceOptions<'strapi'> & Required<BaseStrapiOptions> & StrapiCredentials } StrapiOptionsAssembled
+ */
+
+/**
+ * @satisfies {Partial<StrapiOptions>}
+ */
+const STRAPI_OPTION_DEFAULTS = {
+	version: '3',
+	limit: 100,
+	maxNumPages: -1,
+	pageNumZeroPad: 0
+};
 
 class StrapiVersionUtils {
 	/**
@@ -160,7 +117,7 @@ class StrapiVersionUtils {
 	}
 
 	/**
-	 * @param {object} result
+	 * @param {unknown} result
 	 * @returns {boolean}
 	 */
 	canFetchMore(result) {
@@ -286,7 +243,7 @@ class StrapiV3 extends StrapiVersionUtils {
 	}
 
 	/**
-	 * @param {object} result
+	 * @param {unknown} result
 	 * @returns {boolean}
 	 */
 	canFetchMore(result) {
@@ -297,7 +254,7 @@ class StrapiV3 extends StrapiVersionUtils {
 }
 
 /**
- * @extends {ContentSource<StrapiOptions>}
+ * @extends {ContentSource<StrapiOptionsAssembled>}
  */
 class StrapiSource extends ContentSource {
 	/**
@@ -308,7 +265,7 @@ class StrapiSource extends ContentSource {
 
 	/**
 	 * 
-	 * @param {*} config 
+	 * @param {StrapiOptions} config 
 	 * @param {Logger} logger
 	 */
 	constructor(config, logger) {
@@ -334,13 +291,23 @@ class StrapiSource extends ContentSource {
 	 */
 	async fetchContent() {
 		const result = new ContentResult();
+
+		/**
+		 * @type {string | undefined}
+		 */
+		let token;
 		
-		if (!this.config.token) {
-			this.config.token = await this._getJwt(this.config.identifier, this.config.password);
+		if ('token' in this.config) {
+			token = this.config.token;
+		} else {
+			if (!this.config.identifier || !this.config.password) {
+				throw new Error('Either a token or an identifier and password must be provided for a Strapi source');
+			}
+			token = await this._getJwt(this.config.identifier, this.config.password);
 		}
 		
 		for (const query of this.config.queries) {
-			await this._fetchPages(query, this.config.token, result, {
+			await this._fetchPages(query, token, result, {
 				start: 0,
 				limit: this.config.limit
 			});
@@ -421,7 +388,7 @@ class StrapiSource extends ContentSource {
 	}
 	
 	/**
-	 * 
+	 * @private
 	 * @param {Object} content 
 	 * @return {Array<string>}
 	 */
@@ -439,8 +406,10 @@ class StrapiSource extends ContentSource {
 	}
 	
 	/**
+	 * @private
 	 * @param {string} identifier
 	 * @param {string} password
+	 * @returns {Promise<string>} The JSON web token generated by Strapi
 	 */
 	async _getJwt(identifier, password) {
 		this.logger.info(chalk.gray(`Retrieving JWT for ${identifier}...`));
@@ -467,15 +436,48 @@ class StrapiSource extends ContentSource {
 	}
 	
 	/**
-	 * 
-	 * @param {*} config 
-	 * @returns {StrapiOptions}
+	 * @private
+	 * @param {StrapiOptions} config 
+	 * @returns {StrapiOptionsAssembled}
 	 */
 	static _assembleConfig(config) {
-		return new StrapiOptions({
-			...config,
-			...Credentials.getCredentials(config.id)
-		});
+		const creds = Credentials.getCredentials(config.id);
+
+		if (creds) {
+			if (!StrapiSource._validateCrendentials(creds)) {
+				throw new Error(
+					`Strapi credentials for source '${config.id}' are invalid.`
+				);
+			}
+			
+			return {
+				...STRAPI_OPTION_DEFAULTS,
+				...config,
+				...creds
+			};
+		}
+
+		if (!StrapiSource._validateCrendentials(config)) {
+			throw new Error(
+				`No Strapi credentials found for source '${config.id}' in credentials file or launchpad config.`
+			);
+		}
+
+		return {
+			...STRAPI_OPTION_DEFAULTS,
+			...config
+		};
+	}
+
+	/**
+	 * @private
+	 * @param {unknown} creds 
+	 * @returns {creds is StrapiCredentials}
+	 */
+	static _validateCrendentials(creds) {
+		if (typeof creds !== 'object' || creds === null) { return false; };
+
+		return ('identifier' in creds && 'password' in creds) || 'token' in creds;
 	}
 }
 

--- a/packages/content/lib/credentials.js
+++ b/packages/content/lib/credentials.js
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { Logger } from '@bluecadet/launchpad-utils';
 
 /**
- * @type {any}
+ * @type {Record<string, unknown>}
  */
 let creds = {};
 
@@ -42,7 +42,7 @@ class Credentials {
 			return creds[id];
 		} else {
 			this.logger.error(`Can't find credentials for '${id}'`);
-			return {};
+			return null;
 		}
 	}
 }

--- a/packages/content/lib/launchpad-content.js
+++ b/packages/content/lib/launchpad-content.js
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 
 import Credentials from './credentials.js';
-import ContentOptions from './content-options.js';
+import { CONTENT_OPTION_DEFAULTS, DOWNLOAD_PATH_TOKEN, TIMESTAMP_TOKEN } from './content-options.js';
 
 import ContentSource from './content-sources/content-source.js';
 import AirtableSource from './content-sources/airtable-source.js';
@@ -24,18 +24,26 @@ import SanityToPlainTransform from './content-transforms/sanity-to-plain.js';
 import SanityToHtmlTransform from './content-transforms/sanity-to-html.js';
 import SanityToMarkdownTransform from './content-transforms/sanity-to-markdown.js';
 
-export class ContentSourceTypes {
-	static json = 'json';
-	static airtable = 'airtable';
-	static contentful = 'contentful';
-	static sanity = 'sanity';
-	static strapi = 'strapi';
-}
+/**
+ * @enum {import('./content-options.js').AllSourceOptions['type']}
+ */
+export const ContentSourceTypes = {
+	/** @type {'json'} */
+	json: 'json',
+	/** @type {'airtable'} */
+	airtable: 'airtable',
+	/** @type {'contentful'} */
+	contentful: 'contentful',
+	/** @type {'sanity'} */
+	sanity: 'sanity',
+	/** @type {'strapi'} */
+	strapi: 'strapi'
+};
 
 export class LaunchpadContent {
 	/**
 	 * Creates a new LaunchpadContent and downloads content using an optional user config object.
-	 * @param {ContentOptions} [config]
+	 * @param {import('./content-options.js').ContentOptions} [config]
 	 * @returns {Promise.<LaunchpadContent>} Promise that resolves with the new LaunchpadContent instance.
 	 */
 	static async createAndDownload(config) {
@@ -52,7 +60,7 @@ export class LaunchpadContent {
 		}
 	}
 	
-	/** @type {ContentOptions} */
+	/** @type {Required<import('./content-options.js').ContentOptions>} */
 	_config;
 	
 	/** @type {Logger} */
@@ -68,11 +76,11 @@ export class LaunchpadContent {
 	_contentTransforms = new Map();
 
 	/**
-	 * @param {ContentOptions|Object} [config]
+	 * @param {import('./content-options.js').ContentOptions} [config]
 	 * @param {Logger} [parentLogger]
 	 */
 	constructor(config, parentLogger) {
-		this._config = new ContentOptions(config);
+		this._config = { ...CONTENT_OPTION_DEFAULTS, ...config };
 		this._logger = LogManager.getInstance().getLogger('content', parentLogger);
 		this._mediaDownloader = new MediaDownloader(this._logger);
 		this._contentTransforms.set('mdToHtml', new MdToHtmlTransform(false));
@@ -301,7 +309,7 @@ export class LaunchpadContent {
 	}
 	
 	/**
-	 * @param {Array<any>|Object} sourceConfigs 
+	 * @param {import('./content-options.js').ContentOptions['sources']} sourceConfigs 
 	 * @returns {Array<ContentSource>}
 	 */
 	_createSources(sourceConfigs) {
@@ -313,7 +321,7 @@ export class LaunchpadContent {
 		const sources = [];
 
 		/**
-		 * @type {Array<any>}
+		 * @type {(import('./content-options.js').AllSourceOptions)[]}
 		 */
 		let sourceConfigArray = [];
 		
@@ -323,48 +331,47 @@ export class LaunchpadContent {
 			const entries = Object.entries(sourceConfigs);
 			for (const [id, config] of entries) {
 				sourceConfigArray.push({
-					id,
-					...config
+					...config,
+					id
 				});
 			}
 		} else {
 			sourceConfigArray = sourceConfigs;
 		}
-		
+
 		for (const sourceConfig of sourceConfigArray) {
 			try {
 				/**
 				 * @type {ContentSource}
 				 */
 				let source;
-				const config = {
-					...this._config,
-					...sourceConfig
-				};
 
 				switch (sourceConfig.type) {
 					case ContentSourceTypes.airtable:
-						source = new AirtableSource(config, this._logger);
+						source = new AirtableSource(sourceConfig, this._logger);
 						break;
 					case ContentSourceTypes.contentful:
-						source = new ContentfulSource(config, this._logger);
+						source = new ContentfulSource(sourceConfig, this._logger);
 						break;
 					case ContentSourceTypes.strapi:
-						source = new StrapiSource(config, this._logger);
+						source = new StrapiSource(sourceConfig, this._logger);
 						break;
 					case ContentSourceTypes.sanity:
-						source = new SanitySource(config, this._logger);
+						source = new SanitySource(sourceConfig, this._logger);
 						break;
 					case ContentSourceTypes.json:
 					default:
 						if (sourceConfig.type !== ContentSourceTypes.json) {
-							if (config && sourceConfig.type) {
-								this._logger.warn(`Unknown source type '${sourceConfig.type}'. Defaulting ${config.id} to '${ContentSourceTypes.json}'.`);
+							// @ts-expect-error - user may have passed in a custom type that we don't know about
+							if ((sourceConfig).type) {
+								// @ts-expect-error
+								this._logger.warn(`Unknown source type '${sourceConfig.type}'. Defaulting ${sourceConfig.id} to '${ContentSourceTypes.json}'.`);
 							} else {
-								this._logger.info(`Defaulting source '${config.id}' to 'json'.`);
+								// @ts-expect-error
+								this._logger.info(`Defaulting source '${sourceConfig.id}' to 'json'.`);
 							}
 						}
-						source = new JsonSource(config, this._logger);
+						source = new JsonSource(sourceConfig, this._logger);
 						break;
 				}
 
@@ -385,14 +392,13 @@ export class LaunchpadContent {
 	 * @returns {Promise<ContentResult>}
 	 */
 	async _downloadMedia(source, result) {
-		await this._mediaDownloader.sync(result.mediaDownloads, new ContentOptions({
-			...this._config,
+		await this._mediaDownloader.sync(result.mediaDownloads, {
 			...source.config,
 			...{
 				downloadPath: this.getDownloadPath(source),
 				tempPath: this.getTempPath(source)
 			}
-		}));
+		});
 
 		return result;
 	}
@@ -495,11 +501,11 @@ export class LaunchpadContent {
 	 * @param {string} downloadPath
 	 */
 	_getDetokenizedPath(tokenizedPath, downloadPath) {
-		if (tokenizedPath.includes(ContentOptions.TIMESTAMP_TOKEN)) {
-			tokenizedPath = tokenizedPath.replace(ContentOptions.TIMESTAMP_TOKEN, FileUtils.getDateString());
+		if (tokenizedPath.includes(TIMESTAMP_TOKEN)) {
+			tokenizedPath = tokenizedPath.replace(TIMESTAMP_TOKEN, FileUtils.getDateString());
 		}
-		if (tokenizedPath.includes(ContentOptions.DOWNLOAD_PATH_TOKEN)) {
-			tokenizedPath = tokenizedPath.replace(ContentOptions.DOWNLOAD_PATH_TOKEN, downloadPath);
+		if (tokenizedPath.includes(DOWNLOAD_PATH_TOKEN)) {
+			tokenizedPath = tokenizedPath.replace(DOWNLOAD_PATH_TOKEN, downloadPath);
 		}
 		return path.resolve(tokenizedPath);
 	}

--- a/packages/content/lib/launchpad-content.js
+++ b/packages/content/lib/launchpad-content.js
@@ -60,7 +60,7 @@ export class LaunchpadContent {
 		}
 	}
 	
-	/** @type {Required<import('./content-options.js').ContentOptionsResolved>} */
+	/** @type {Required<import('./content-options.js').ResolvedContentOptions>} */
 	_config;
 	
 	/** @type {Logger} */

--- a/packages/content/lib/launchpad-content.js
+++ b/packages/content/lib/launchpad-content.js
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 
 import Credentials from './credentials.js';
-import { CONTENT_OPTION_DEFAULTS, DOWNLOAD_PATH_TOKEN, TIMESTAMP_TOKEN } from './content-options.js';
+import { CONTENT_OPTION_DEFAULTS, DOWNLOAD_PATH_TOKEN, TIMESTAMP_TOKEN, resolveContentOptions } from './content-options.js';
 
 import ContentSource from './content-sources/content-source.js';
 import AirtableSource from './content-sources/airtable-source.js';
@@ -60,7 +60,7 @@ export class LaunchpadContent {
 		}
 	}
 	
-	/** @type {Required<import('./content-options.js').ContentOptions>} */
+	/** @type {Required<import('./content-options.js').ContentOptionsResolved>} */
 	_config;
 	
 	/** @type {Logger} */
@@ -80,7 +80,7 @@ export class LaunchpadContent {
 	 * @param {Logger} [parentLogger]
 	 */
 	constructor(config, parentLogger) {
-		this._config = { ...CONTENT_OPTION_DEFAULTS, ...config };
+		this._config = resolveContentOptions(config);
 		this._logger = LogManager.getInstance().getLogger('content', parentLogger);
 		this._mediaDownloader = new MediaDownloader(this._logger);
 		this._contentTransforms.set('mdToHtml', new MdToHtmlTransform(false));
@@ -393,11 +393,9 @@ export class LaunchpadContent {
 	 */
 	async _downloadMedia(source, result) {
 		await this._mediaDownloader.sync(result.mediaDownloads, {
-			...source.config,
-			...{
-				downloadPath: this.getDownloadPath(source),
-				tempPath: this.getTempPath(source)
-			}
+			...this._config,
+			downloadPath: this.getDownloadPath(source),
+			tempPath: this.getTempPath(source)
 		});
 
 		return result;

--- a/packages/content/lib/utils/file-utils.js
+++ b/packages/content/lib/utils/file-utils.js
@@ -82,7 +82,7 @@ export class FileUtils {
     
 	/**
      * 
-     * @param {JSON|string} json 
+     * @param {unknown} json 
      * @param {string} filePath 
      * @param {boolean} appendJsonExtension
      */
@@ -97,8 +97,8 @@ export class FileUtils {
     
 	/**
      * Removes all files and subdirectories of `dirPath`, except for `exclude`.
-     * @param {*} dirPath Any absolute directory path
-     * @param {*} exclude Any glob patterns (e.g. `*.json|*.csv|my-important-folder`)
+     * @param {string} dirPath Any absolute directory path
+     * @param {string} exclude Any glob patterns (e.g. `*.json|*.csv|my-important-folder`)
      */
 	static removeFilesFromDir(dirPath, exclude = '') {
 		let glob = dirPath;

--- a/packages/content/lib/utils/json-utils.js
+++ b/packages/content/lib/utils/json-utils.js
@@ -3,7 +3,7 @@ import getUrls from 'get-urls';
 class JsonUtils {
 	/**
      * Parses URLs from json object using include/exclude regexps
-     * @param {JSON} json 
+     * @param {unknown} json 
      * @param {any} [options] 
      * @param {RegExp|string} [include] 
      * @param {RegExp|string} [exclude] 

--- a/packages/content/lib/utils/markdown-it-italic-bold.js
+++ b/packages/content/lib/utils/markdown-it-italic-bold.js
@@ -1,4 +1,3 @@
-
 /**
  * @type {import('markdown-it/lib/renderer.js').RenderRule}
  */

--- a/packages/content/lib/utils/media-downloader.js
+++ b/packages/content/lib/utils/media-downloader.js
@@ -9,7 +9,6 @@ import sharp from 'sharp'; // image manipulation
 import cliProgress from 'cli-progress';
 
 import FileUtils from './file-utils.js';
-import { ContentOptions } from '../content-options.js';
 import { MediaDownload } from '../content-sources/content-result.js';
 
 const pipeline = promisify(stream.pipeline);
@@ -44,7 +43,7 @@ export class MediaDownloader {
 	 * the downloads, `options.dest` will remain untouched.
 	 *
 	 * @param {Array<MediaDownload>} downloads
-	 * @param {ContentOptions} options
+	 * @param {import('../content-options.js').ContentOptionsResolved} options
 	 */
 	async sync(downloads, options) {
 		this.logger.info(`Syncing ${chalk.cyan(downloads.length)} files`);
@@ -208,7 +207,7 @@ export class MediaDownloader {
 	 * @param {MediaDownload} task
 	 * @param {string} tempDir Directory path for temporary files
 	 * @param {string} destDir Directory path for final downloaded files
-	 * @param {ContentOptions} options Content and source options
+	 * @param {import('../content-options.js').ContentOptionsResolved} options Content and source options
 	 * @returns {Promise<string|undefined>} Resolves with the downloaded file path
 	 */
 	async download(task, tempDir, destDir, options) {

--- a/packages/content/lib/utils/media-downloader.js
+++ b/packages/content/lib/utils/media-downloader.js
@@ -43,7 +43,7 @@ export class MediaDownloader {
 	 * the downloads, `options.dest` will remain untouched.
 	 *
 	 * @param {Array<MediaDownload>} downloads
-	 * @param {import('../content-options.js').ContentOptionsResolved} options
+	 * @param {import('../content-options.js').ResolvedContentOptions} options
 	 */
 	async sync(downloads, options) {
 		this.logger.info(`Syncing ${chalk.cyan(downloads.length)} files`);
@@ -207,7 +207,7 @@ export class MediaDownloader {
 	 * @param {MediaDownload} task
 	 * @param {string} tempDir Directory path for temporary files
 	 * @param {string} destDir Directory path for final downloaded files
-	 * @param {import('../content-options.js').ContentOptionsResolved} options Content and source options
+	 * @param {import('../content-options.js').ResolvedContentOptions} options Content and source options
 	 * @returns {Promise<string|undefined>} Resolves with the downloaded file path
 	 */
 	async download(task, tempDir, destDir, options) {

--- a/packages/launchpad/README.md
+++ b/packages/launchpad/README.md
@@ -46,7 +46,9 @@ Run `npx launchpad --help` to see all available commands.
 Each [launchpad package](#packages) is configured via its own section in `launchpad.config.js`. Below is a simple example that uses the [`content`](/packages/content) package to download JSON and images from Flickr and [`monitor`](/packages/monitor) to launch a single app:
 
 ```js
-export default {
+import { defineConfig } from "@bluecadet/launchpad";
+
+export default defineConfig({
   "content": {
     "sources": [
       {
@@ -69,7 +71,7 @@ export default {
       }
     ]
   }
-}
+});
 ```
 
 *Note: [Scaffold](/packages/scaffold) is configured separately in a PowerShell file. This is a guided process when you run `npx launchpad scaffold`.*

--- a/packages/launchpad/index.js
+++ b/packages/launchpad/index.js
@@ -48,33 +48,33 @@ launchFromCli(import.meta, {
 		return argv;
 	}
 }).then(async config => {
-	const launchpad = new LaunchpadCore(config);
+	// const launchpad = new LaunchpadCore(config);
 	
-	switch (config.startupCommand) {
-		case StartupCommands.SCAFFOLD: {
-			await launchScaffold(config);
-			break;
-		}
-		case StartupCommands.CONTENT: {
-			await launchpad.updateContent();
-			await launchpad.shutdown();
-			break;
-		}
-		case StartupCommands.MONITOR: {
-			await launchpad.startApps();
-			break;
-		}
-		case StartupCommands.STOP: {
-			await launchpad.stopApps();
-			await LaunchpadMonitor.kill();
-			break;
-		}
-		case StartupCommands.START:
-		default: {
-			await launchpad.startup();
-			break;
-		}
-	}
+	// switch (config.startupCommand) {
+	// 	case StartupCommands.SCAFFOLD: {
+	// 		await launchScaffold(config);
+	// 		break;
+	// 	}
+	// 	case StartupCommands.CONTENT: {
+	// 		await launchpad.updateContent();
+	// 		await launchpad.shutdown();
+	// 		break;
+	// 	}
+	// 	case StartupCommands.MONITOR: {
+	// 		await launchpad.startApps();
+	// 		break;
+	// 	}
+	// 	case StartupCommands.STOP: {
+	// 		await launchpad.stopApps();
+	// 		await LaunchpadMonitor.kill();
+	// 		break;
+	// 	}
+	// 	case StartupCommands.START:
+	// 	default: {
+	// 		await launchpad.startup();
+	// 		break;
+	// 	}
+	// }
 }).catch(err => {
 	if (err) {
 		console.error('Launch error', err);

--- a/packages/launchpad/index.js
+++ b/packages/launchpad/index.js
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
 import { LaunchpadCore } from './lib/launchpad-core.js';
-import { launch as launchContent } from '@bluecadet/launchpad-content';
-import { launch as launchMonitor, LaunchpadMonitor } from '@bluecadet/launchpad-monitor';
-import { launch as launchScaffold } from '@bluecadet/launchpad-scaffold';
 import { launchFromCli } from '@bluecadet/launchpad-utils';
+export { defineConfig } from './lib/launchpad-options.js';
 
 export default LaunchpadCore;
 

--- a/packages/launchpad/lib/command-center.js
+++ b/packages/launchpad/lib/command-center.js
@@ -1,18 +1,12 @@
 import chalk from 'chalk';
 import autoBind from 'auto-bind';
-import { LogManager, Logger, TaskQueue, TaskQueueOptions, execScript } from '@bluecadet/launchpad-utils';
-import CommandHooks, { ExecHook } from './command-hooks.js';
+import { LogManager, Logger, TaskQueue, execScript } from '@bluecadet/launchpad-utils';
+import CommandHooks from './command-hooks.js';
 
-export class CommandOptions {
-	constructor({
-		tasks = new TaskQueueOptions()
-	} = {}) {
-		/**
-		 * @type {TaskQueueOptions}
-		 */
-		this.tasks = new TaskQueueOptions(tasks);
-	}
-}
+/**
+ * @typedef CommandOptions
+ * @property {import('@bluecadet/launchpad-utils/lib/task-queue.js').TaskQueueOptions} [tasks]
+ */
 
 export class CommandCenter {
 	/** @type {CommandOptions} */
@@ -29,12 +23,12 @@ export class CommandCenter {
 	
 	/**
 	 * 
-	 * @param {CommandOptions|Object} [config] 
+	 * @param {CommandOptions} [config] 
 	 * @param {Logger} [logger]
 	 */
 	constructor(config, logger) {
 		autoBind(this);
-		this._config = new CommandOptions(config);
+		this._config = config || {};
 		this._logger = logger || LogManager.getInstance().getLogger();
 		this._tasks = new TaskQueue(this._config.tasks, this._logger);
 	}
@@ -79,7 +73,7 @@ export class CommandCenter {
 	addCommandHooks(commandHooks) {
 		/**
 		 * 
-		 * @param {ExecHook[]} hooks 
+		 * @param {import('./command-hooks.js').ExecHook[]} hooks 
 		 * @param {boolean} isPre 
 		 */
 		const add = (hooks, isPre) => {

--- a/packages/launchpad/lib/command-hooks.js
+++ b/packages/launchpad/lib/command-hooks.js
@@ -13,7 +13,7 @@
 
 export class CommandHooks {
 	/**
-	 * @param {Record<string, HookMapping>} hooks 
+	 * @param {HookMapping} hooks 
 	 */
 	constructor(hooks = {}) {
 		/**
@@ -33,7 +33,7 @@ export class CommandHooks {
 	}
 	
 	/**
-	 * @param {Record<string, HookMapping>} hooks 
+	 * @param {HookMapping} hooks 
 	 */
 	parse(hooks = {}) {
 		if (!hooks) {
@@ -51,34 +51,19 @@ export class CommandHooks {
 				}
 				
 				if (key.startsWith('pre-')) {
-					this.preHooks.push(new ExecHook({ command, script }));
+					this.preHooks.push({ command, script });
 				} else {
-					this.postHooks.push(new ExecHook({ command, script }));
+					this.postHooks.push({ command, script });
 				}
 			}
 		}
 	}
 }
 
-export class ExecHook {
-	/**
-	 * @param {object} options
-	 * @param {string} options.command
-	 * @param {string} options.script
-	 */
-	constructor({
-		command,
-		script
-	}) {
-		/**
-		 * @type {string}
-		 */
-		this.command = command;
-		/**
-		 * @type {string}
-		 */
-		this.script = script;
-	}
-}
+/**
+ * @typedef ExecHook
+ * @property {string} command
+ * @property {string} script
+ */
 
 export default CommandHooks;

--- a/packages/launchpad/lib/launchpad-core.js
+++ b/packages/launchpad/lib/launchpad-core.js
@@ -4,17 +4,18 @@
 
 import autoBind from 'auto-bind';
 
-import LaunchpadOptions from './launchpad-options.js';
 import { LogManager, Logger, onExit } from '@bluecadet/launchpad-utils';
 import LaunchpadContent from '@bluecadet/launchpad-content';
 import LaunchpadMonitor from '@bluecadet/launchpad-monitor';
 import CommandCenter, { Command } from './command-center.js';
+import { resolveLaunchpadOptions } from './launchpad-options.js';
+import CommandHooks from './command-hooks.js';
 
 /**
  * Core Launchpad class to configure, monitor apps, download content and manage logs.
  */
 export class LaunchpadCore {
-	/** @type {LaunchpadOptions} */
+	/** @type {import('./launchpad-options.js').LaunchpadOptionsResolved} */
 	_config;
 	
 	/** @type {Logger} */
@@ -37,12 +38,12 @@ export class LaunchpadCore {
 	
 	/**
 	 * 
-	 * @param {LaunchpadOptions|Object} config 
+	 * @param {import('./launchpad-options.js').LaunchpadOptions} config 
 	 */
 	constructor(config) {
 		autoBind(this);
 		
-		this._config = new LaunchpadOptions(config);
+		this._config = resolveLaunchpadOptions(config);
 		this._logger = LogManager.getInstance(this._config.logging).getLogger();
 		this._commands = new CommandCenter(this._config.commands, this._logger);
 		this._content = new LaunchpadContent(this._config.content, this._logger);
@@ -54,7 +55,7 @@ export class LaunchpadCore {
 		this._commands.add(new Command({ name: 'stop-apps', callback: this._runStopApps }));
 		this._commands.add(new Command({ name: 'update-content', callback: this._runUpdateContent }));
 		
-		this._commands.addCommandHooks(this._config.hooks);
+		this._commands.addCommandHooks(new CommandHooks(this._config.hooks));
 		
 		if (this._config.shutdownOnExit) {
 			onExit(this.shutdown);

--- a/packages/launchpad/lib/launchpad-core.js
+++ b/packages/launchpad/lib/launchpad-core.js
@@ -15,7 +15,7 @@ import CommandHooks from './command-hooks.js';
  * Core Launchpad class to configure, monitor apps, download content and manage logs.
  */
 export class LaunchpadCore {
-	/** @type {import('./launchpad-options.js').LaunchpadOptionsResolved} */
+	/** @type {import('./launchpad-options.js').ResolvedLaunchpadOptions} */
 	_config;
 	
 	/** @type {Logger} */

--- a/packages/launchpad/lib/launchpad-options.js
+++ b/packages/launchpad/lib/launchpad-options.js
@@ -28,5 +28,13 @@ export function resolveLaunchpadOptions(config) {
 }
 
 /**
- * @typedef {ReturnType<typeof resolveLaunchpadOptions>} LaunchpadOptionsResolved
+ * @typedef {ReturnType<typeof resolveLaunchpadOptions>} ResolvedLaunchpadOptions
  */
+
+/**
+ * @param {LaunchpadOptions} config 
+ * @returns {LaunchpadOptions}
+ */
+export function defineConfig(config) {
+	return config;
+}

--- a/packages/launchpad/lib/launchpad-options.js
+++ b/packages/launchpad/lib/launchpad-options.js
@@ -2,62 +2,31 @@
  * @module launchpad-options
  */
 
-import { LogOptions } from '@bluecadet/launchpad-utils';
-import { ContentOptions } from '@bluecadet/launchpad-content';
-import { MonitorOptions } from '@bluecadet/launchpad-monitor';
-import { CommandOptions } from './command-center.js';
-import { CommandHooks } from './command-hooks.js';
+/**
+ * @typedef LaunchpadOptions Combined options to initialize Launchpad.
+ * @property {import("@bluecadet/launchpad-content").ContentOptions} [content]
+ * @property {import("@bluecadet/launchpad-monitor").MonitorOptions} [monitor]
+ * @property {import("./command-center").CommandOptions} [commands]
+ * @property {import("./command-hooks").HookMapping} [hooks]
+ * @property {import("@bluecadet/launchpad-utils/lib/log-manager").LogOptions} [logging]
+ * @property {boolean} [shutdownOnExit] Will listen for exit events. Defaults to 'true'
+ */
+
+const LAUNCHPAD_OPTIONS_DEFAULTS = {
+	shutdownOnExit: true
+};
 
 /**
- * Combined options to initialize Launchpad.
+ * Applies defaults to the provided launchpad config.
+ * @param {LaunchpadOptions} config
  */
-export class LaunchpadOptions {
-	/**
-	 * @param {any} options
-	 */
-	constructor({
-		content = new ContentOptions(),
-		monitor = new MonitorOptions(),
-		commands = new CommandOptions(),
-		hooks = new CommandHooks(),
-		logging = new LogOptions(),
-		shutdownOnExit = true,
-		...rest
-	} = {}) {
-		/**
-		 * Will listen for exit events 
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.shutdownOnExit = true;
-		
-		/**
-		 * @type {ContentOptions}
-		 */
-		this.content = new ContentOptions(content);
-		
-		/**
-		 * @type {MonitorOptions}
-		 */
-		this.monitor = new MonitorOptions(monitor);
-		
-		/**
-		 * @type {CommandOptions}
-		 */
-		this.commands = new CommandOptions(commands);
-		
-		/**
-		 * @type {CommandHooks}
-		 */
-		this.hooks = new CommandHooks(hooks);
-		
-		/**
-		 * @type {LogOptions}
-		 */
-		this.logging = new LogOptions(logging);
-		
-		Object.assign(this, rest);
-	}
+export function resolveLaunchpadOptions(config) {
+	return {
+		...LAUNCHPAD_OPTIONS_DEFAULTS,
+		...config
+	};
 }
 
-export default LaunchpadOptions;
+/**
+ * @typedef {ReturnType<typeof resolveLaunchpadOptions>} LaunchpadOptionsResolved
+ */

--- a/packages/monitor/lib/app-log-router.js
+++ b/packages/monitor/lib/app-log-router.js
@@ -4,18 +4,18 @@ import { Tail } from 'tail';
 import autoBind from 'auto-bind';
 import { SubEmitterSocket } from 'axon'; // used by PM2
 import { Logger, LogManager } from '@bluecadet/launchpad-utils';
-import { AppOptions, AppLogOptions, LogModes } from './monitor-options.js';
+import { LogModes } from './monitor-options.js';
 
 class LogRelay {
 	/**
 	 * @protected
-	 * @type {AppOptions}
+	 * @type {import('./monitor-options.js').ResolvedAppOptions}
 	 */
 	_appOptions;
 
 	/**
 	 * @protected
-	 * @type {AppLogOptions}
+	 * @type {import('./monitor-options.js').ResolvedAppOptions['logging']}
 	 */
 	_logOptions;
 
@@ -26,7 +26,7 @@ class LogRelay {
 	_logger;
 
 	/**
-	 * @param {AppOptions} appOptions
+	 * @param {import('./monitor-options.js').ResolvedAppOptions} appOptions
 	 * @param {Logger} logger
 	 */
 	constructor(appOptions, logger) {
@@ -77,7 +77,7 @@ class FileLogRelay extends LogRelay {
 	_errTail = null;
 
 	/**
-	 * @param {AppOptions} appOptions
+	 * @param {import('./monitor-options.js').ResolvedAppOptions} appOptions
 	 * @param {Logger} logger
 	 */
 	constructor(appOptions, logger) {
@@ -193,7 +193,7 @@ class FileLogRelay extends LogRelay {
 
 class BusLogRelay extends LogRelay {
 	/**
-	 * @param {AppOptions} appOptions
+	 * @param {import('./monitor-options.js').ResolvedAppOptions} appOptions
 	 * @param {Logger} logger
 	 */
 	constructor(appOptions, logger) {
@@ -279,7 +279,7 @@ export default class AppLogRouter {
 	}
 
 	/**
-	 * @param {AppOptions} appOptions
+	 * @param {import('./monitor-options.js').ResolvedAppOptions} appOptions
 	 * @return {void}
 	 */
 	initAppOptions(appOptions) {

--- a/packages/monitor/lib/launchpad-monitor.js
+++ b/packages/monitor/lib/launchpad-monitor.js
@@ -8,15 +8,14 @@ import pDebounce from 'p-debounce';
 import pm2 from 'pm2';
 import { spawn } from 'cross-spawn';
 import { SubEmitterSocket } from 'axon'; // used by PM2
-import util from 'util';
 
 import { LogManager, Logger } from '@bluecadet/launchpad-utils';
 import AppLogRouter from './app-log-router.js';
-import { AppLogOptions, AppOptions, MonitorOptions, WindowOptions } from './monitor-options.js';
-import sortWindows, { SortApp } from './utils/sort-windows.js';
+import sortWindows from './utils/sort-windows.js';
+import { resolveMonitorConfig } from './monitor-options.js';
 
 export class LaunchpadMonitor {
-	/** @type {MonitorOptions} */
+	/** @type {import('./monitor-options.js').ResolvedMonitorOptions} */
 	_config;
 	
 	/**
@@ -41,7 +40,7 @@ export class LaunchpadMonitor {
 	/**
 	 * Creates a new instance, starts it with the
 	 * config and resolves with the monitor instance.
-	 * @param {MonitorOptions} config 
+	 * @param {import('./monitor-options.js').MonitorOptions} config 
 	 * @returns {Promise<LaunchpadMonitor>} Promise that resolves with the new LaunchpadMonitor instance.
 	 */
 	static async createAndStart(config) {
@@ -78,13 +77,13 @@ export class LaunchpadMonitor {
 	
 	/**
 	 * 
-	 * @param {MonitorOptions|Object} config 
+	 * @param {import('./monitor-options.js').MonitorOptions} config 
    * @param {Logger} [parentLogger]
 	 */
 	constructor(config, parentLogger) {
 		autoBind(this);
 		this._logger = LogManager.getInstance().getLogger('monitor', parentLogger);
-		this._config = new MonitorOptions(config);
+		this._config = resolveMonitorConfig(config);
 		this._appLogRouter = new AppLogRouter(this._logger);
 		this._applyWindowSettings = pDebounce(
 			this._applyWindowSettings,
@@ -255,7 +254,7 @@ export class LaunchpadMonitor {
 	/**
 	 * Get the startup options for appName
 	 * @param {string} appName 
-	 * @returns {AppOptions}
+	 * @returns {import('./monitor-options.js').ResolvedAppOptions}
 	 */
 	getAppOptions(appName) {
 		const options = this._config.apps.find(app => app.pm2.name === appName);
@@ -378,16 +377,14 @@ export class LaunchpadMonitor {
 	}
 	
 	/**
-	 * @param {AppOptions} options 
-	 * @returns {AppOptions} 
+	 * @param {import('./monitor-options.js').ResolvedAppOptions} options 
+	 * @returns {import('./monitor-options.js').ResolvedAppOptions} 
 	 */
 	_initAppOptions(options) {
 		if (!options.pm2 || !options.pm2.name) {
 			this._logger.error('PM2 config is incomplete or missing:', options);
 			return options;
 		}
-		options.logging = new AppLogOptions(options.logging);
-		options.windows = new WindowOptions(options.windows);
 		
 		// @ts-expect-error - Undocumented PM2 field that can prevent your apps from actually showing on launch. Set this to false to prevent that default behavior.
 		options.pm2.windowsHide = options.windows.hide;
@@ -404,10 +401,12 @@ export class LaunchpadMonitor {
 	 */
 	async _applyWindowSettings(appNames = []) {
 		appNames = this._validateAppNames(appNames);
+		/** @type {import('./utils/sort-windows.js').SortApp[]} */
 		const apps = [];
 		
 		for (const appName of appNames) {
-			const sortApp = new SortApp(this.getAppOptions(appName));
+			/** @type {import('./utils/sort-windows.js').SortApp} */
+			const sortApp = { options: this.getAppOptions(appName), pid: null };
 
 			try {
 				const process = await this.getAppProcess(appName);

--- a/packages/monitor/lib/launchpad-monitor.js
+++ b/packages/monitor/lib/launchpad-monitor.js
@@ -77,7 +77,7 @@ export class LaunchpadMonitor {
 	
 	/**
 	 * 
-	 * @param {import('./monitor-options.js').MonitorOptions} config 
+	 * @param {import('./monitor-options.js').MonitorOptions} [config] 
    * @param {Logger} [parentLogger]
 	 */
 	constructor(config, parentLogger) {

--- a/packages/monitor/lib/monitor-options.js
+++ b/packages/monitor/lib/monitor-options.js
@@ -122,3 +122,11 @@ export function resolveMonitorConfig(config) {
 /**
  * @typedef {ResolvedMonitorOptions['apps'][number]} ResolvedAppOptions
  */
+
+/**
+ * @param {MonitorOptions} config 
+ * @returns {MonitorOptions}
+ */
+export function defineMonitorConfig(config) {
+	return config;
+}

--- a/packages/monitor/lib/monitor-options.js
+++ b/packages/monitor/lib/monitor-options.js
@@ -5,118 +5,33 @@ import * as pm2 from 'pm2';
  */
 
 /**
- * Top-level options of Launchpad Monitor.
+ * @typedef WindowsApiOptions Global options for how window order should be managed.
+ * @property {number} [debounceDelay] The delay until windows are ordered after launch of in ms. Defaults to 3000. If your app takes a long time to open all of its windows, set this number to a higher value to ensure it can be on top of the launchpad terminal window. Keeping this high also reduces the CPU load if apps relaunch often. see https://github.com/node-ffi-napi/ref-napi/issues/54#issuecomment-1029639256
+ * @property {string} [nodeVersion] The minimum major node version to support window ordering. Node versions < 17 seem to have a fatal bug with the native API, which will intermittently cause V8 to crash hard. Defaults to '>=17.4.0'.
  */
-export class MonitorOptions {
-	/**
-	 * @param {any} options
-	 */
-	constructor({
-		apps = [],
-		deleteExistingBeforeConnect = false,
-		windowsApi = new WindowsApiOptions(),
-		...rest
-	} = {}) {
-		/**
-		 * A list of `AppOptions` to configure which apps to launch and monitor.
-		 * @type {Array<AppOptions>}
-		 * @default []
-		 */
-		this.apps = apps;
-		
-		/**
-		 * Set this to true to delete existing PM2 processes before connecting. If you're running volatile apps or your node process might be quit unexpectedly, this can be helpful to start with a clean slate on startup.
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.deleteExistingBeforeConnect = deleteExistingBeforeConnect;
-		
-		/**
-		 * Advanced configuration for the Windows API, e.g. for managing foreground/minimized/hidden windows.
-		 * @type {WindowsApiOptions} 
-		 */
-		this.windowsApi = new WindowsApiOptions(windowsApi);
-		
-		Object.assign(this, rest);
-	}
+
+const WINDOWS_API_DEFAULTS = {
+	debounceDelay: 3000,
+	nodeVersion: '>=17.4.0'
 };
 
 /**
- * Options for an individual app to monitor.
+ * @typedef WindowOptions Options for how an app's windows should be managed.
+ * @property {boolean} [foreground] Move this app to the foreground once all apps have been launched. Defaults to false.
+ * @property {boolean} [minimize] Minimize this app's windows once all apps have been launched. Defaults to false.
+ * @property {boolean} [hide] Completely hide this app's windows once all apps have been launched. Helpful for headless apps, but note that this might cause issues with GUI-based apps. Defaults to false.
  */
-export class AppOptions {
-	/**
-	 * @param {any} options
-	 */
-	constructor({
-		pm2,
-		windows = new WindowOptions(),
-		logging = new AppLogOptions()
-	} = {}) {
-		if (!pm2) {
-			throw new Error('AppOptions.pm2 is required');
-		}
 
-		/**
-		 * Configure which app to launch and how to monitor it here.
-		 * @see https://pm2.keymetrics.io/docs/usage/application-declaration/#attributes-available
-		 * @type {(pm2.StartOptions & {out_file?: string, error_file?: string})}
-		 */
-		this.pm2 = pm2;
-		
-		/**
-		 * Optional settings for moving this app's main windows to the foreground, minimize or hide them.
-		 * @type {WindowOptions}
-		 * @default new WindowOptions()
-		 */
-		this.windows = windows;
-		
-		/**
-		 * Optional settings for how to log this app's output.
-		 * @type {AppLogOptions}
-		 * @default new AppLogOptions()
-		 */
-		this.logging = logging;
-	}
-}
-
-/**
- * Options for how an app's windows should be managed.
- */
-export class WindowOptions {
-	constructor({
-		foreground = false,
-		minimize = false,
-		hide = false
-	} = {}) {
-		/**
-		 * Move this app to the foreground once all apps have been launched.
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.foreground = foreground;
-		
-		/**
-		 * Minimize this app's windows once all apps have been launched.
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.minimize = minimize;
-		
-		/**
-		 * Completely hide this app's windows once all apps have been launched. Helpful for headless apps, but note that this might cause issues with GUI-based apps.
-		 * 
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.hide = hide;
-	}
-}
+const WINDOW_OPTIONS_DEFAULTS = {
+	foreground: false,
+	minimize: false,
+	hide: false
+};
 
 /**
  * Available log modes for each app
  * @readonly
- * @enum {string}
+ * @enum {'file' | 'bus'}
  */
 export const LogModes = {
 	/**
@@ -133,80 +48,77 @@ export const LogModes = {
 };
 
 /**
- * Options for how an app's logs should be saved, routed and displayed.
+ * @typedef AppLogOptions Options for how an app's logs should be saved, routed and displayed.
+ * @property {boolean} [logToLaunchpadDir] Route application logs to launchpad's log dir instead of pm2's log dir. Defaults to true.
+ * @property {LogModes} [mode] How to grab the app's logs. Supported values: - 'bus': Logs directly from the app's stdout/stderr bus. Can result in interrupted logs if the buffer isn't consistently flushed by an app. - 'file': Logs by tailing the app's log files. Slight lag, but can result in better formatting than bus. Not recommended, as logs cannot be rotated by launchpad. Defaults to 'bus'.
+ * @property {boolean} [showStdout] Whether or not to include output from `stdout`
+ * @property {boolean} [showStderr] Whether or not to include output from `stderr`
  */
-export class AppLogOptions {
-	/**
-	 * @param {any} options
-	 */
-	constructor({
-		logToLaunchpadDir = true,
-		mode = LogModes.LogBusEvents,
-		showStdout = true,
-		showStderr = true
-	} = {}) {
-		/**
-		 * Route application logs to launchpad's log dir instead of pm2's log dir.
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.logToLaunchpadDir = logToLaunchpadDir;
-		
-		/**
-		 * How to grab the app's logs. Supported values:
-		 * - `'bus'`: Logs directly from the app's stdout/stderr bus. Can result in interrupted logs if the buffer isn't consistently flushed by an app.
-		 * - `'file'`: Logs by tailing the app's log files. Slight lag, but can result in better formatting than bus. Not recommended, as logs cannot be rotated by launchpad.
-		 * @type {'bus' | 'file'}
-		 * @default 'bus'
-		 */
-		this.mode = mode;
-		
-		/**
-		 * Whether or not to include output from `stdout`
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.showStdout = showStdout;
-		
-		/**
-		 * Whether or not to include output from `stderr`
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.showStderr = showStderr;
-	}
+
+const APP_LOG_OPTIONS_DEFAULTS = {
+	logToLaunchpadDir: true,
+	mode: LogModes.LogBusEvents,
+	showStdout: true,
+	showStderr: true
+};
+
+/**
+ * @typedef AppOptions Options for an individual app to monitor.
+ * @property {pm2.StartOptions & {out_file?: string, error_file?: string}} pm2 Configure which app to launch and how to monitor it here. see https://pm2.keymetrics.io/docs/usage/application-declaration/#attributes-available
+ * @property {WindowOptions} [windows] Optional settings for moving this app's main windows to the foreground, minimize or hide them.
+ * @property {AppLogOptions} [logging] Optional settings for how to log this app's output.
+ */
+
+const APP_OPTIONS_DEFAULTS = {
+	windows: WINDOW_OPTIONS_DEFAULTS,
+	logging: APP_LOG_OPTIONS_DEFAULTS
+};
+
+/**
+ * @typedef MonitorOptions Top-level options of Launchpad Monitor.
+ * @property {Array<AppOptions>} [apps] A list of `AppOptions` to configure which apps to launch and monitor.
+ * @property {boolean} [deleteExistingBeforeConnect] Set this to true to delete existing PM2 processes before connecting. If you're running volatile apps or your node process might be quit unexpectedly, this can be helpful to start with a clean slate on startup.
+ * @property {WindowsApiOptions} [windowsApi] Advanced configuration for the Windows API, e.g. for managing foreground/minimized/hidden windows.
+ */
+
+export const MONITOR_OPTIONS_DEFAULTS = {
+	apps: [],
+	deleteExistingBeforeConnect: false,
+	windowsApi: WINDOWS_API_DEFAULTS
+};
+
+/**
+ * 
+ * @param {MonitorOptions} config 
+ * @returns 
+ */
+export function resolveMonitorConfig(config) {
+	return {
+		...MONITOR_OPTIONS_DEFAULTS,
+		...config,
+		windowsApi: {
+			...WINDOWS_API_DEFAULTS,
+			...config.windowsApi ?? {}
+		},
+		apps: config?.apps?.map(app => ({
+			...APP_OPTIONS_DEFAULTS,
+			...app,
+			windows: {
+				...WINDOW_OPTIONS_DEFAULTS,
+				...app.windows ?? {}
+			},
+			logging: {
+				...APP_LOG_OPTIONS_DEFAULTS,
+				...app.logging ?? {}
+			}
+		})) ?? []
+	};
 }
 
 /**
- * Global options for how window order should be managed.
+ * @typedef {ReturnType<typeof resolveMonitorConfig>} ResolvedMonitorOptions
  */
-export class WindowsApiOptions {
-	constructor({
-		debounceDelay = 3000,
-		nodeVersion = '>=17.4.0',
-		...rest
-	} = {}) {
-		/**
-		 * The minimum major node version to support window ordering.
-		 * Node versions < 17 seem to have a fatal bug with the native
-		 * API, which will intermittently cause V8 to crash hard.
-		 * @see https://github.com/node-ffi-napi/ref-napi/issues/54#issuecomment-1029639256
-		 * @type {string}
-		 * @default '>=17.4.0'
-		 */
-		this.nodeVersion = nodeVersion;
-		
-		/**
-		 * The delay until windows are ordered after launch of in ms.
-		 * 
-		 * If your app takes a long time to open all of its windows, set this number to a higher value to ensure it can be on top of the launchpad terminal window.
-		 * 
-		 * Keeping this high also reduces the CPU load if apps relaunch often.
-		 * @type {number}
-		 * @default 3000
-		 */
-		this.debounceDelay = debounceDelay;
-		
-		Object.assign(this, rest);
-	}
-}
+
+/**
+ * @typedef {ResolvedMonitorOptions['apps'][number]} ResolvedAppOptions
+ */

--- a/packages/monitor/lib/monitor-options.js
+++ b/packages/monitor/lib/monitor-options.js
@@ -89,7 +89,7 @@ export const MONITOR_OPTIONS_DEFAULTS = {
 
 /**
  * 
- * @param {MonitorOptions} config 
+ * @param {MonitorOptions} [config] 
  * @returns 
  */
 export function resolveMonitorConfig(config) {
@@ -98,7 +98,7 @@ export function resolveMonitorConfig(config) {
 		...config,
 		windowsApi: {
 			...WINDOWS_API_DEFAULTS,
-			...config.windowsApi ?? {}
+			...config?.windowsApi ?? {}
 		},
 		apps: config?.apps?.map(app => ({
 			...APP_OPTIONS_DEFAULTS,

--- a/packages/monitor/lib/utils/sort-windows.js
+++ b/packages/monitor/lib/utils/sort-windows.js
@@ -2,25 +2,12 @@ import semver from 'semver';
 import chalk from 'chalk';
 import { windowManager } from 'node-window-manager';
 import { Logger } from '@bluecadet/launchpad-utils';
-import { AppOptions } from '../monitor-options.js';
 
-export class SortApp {
-	/**
-	 * @type {AppOptions}
-	 */
-	options;
-	/**
-	 * @type {number?}
-	 */
-	pid = null;
-
-	/**
-	 * @param {AppOptions} options
-	 */
-	constructor(options) {
-		this.options = options;
-	}
-}
+/**
+ * @typedef SortApp
+ * @property {import('../monitor-options.js').ResolvedAppOptions} options
+ * @property {number?} pid
+ */
 
 /**
  * 

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -3,4 +3,4 @@ export { default as execScript } from './lib/exec-script.js';
 export { default as launchFromCli } from './lib/launch-from-cli.js';
 export { default as LogManager, Logger } from './lib/log-manager.js';
 export { default as ConfigManager } from './lib/config-manager.js';
-export { default as TaskQueue, TaskQueueOptions, Task } from './lib/task-queue.js';
+export { default as TaskQueue, Task } from './lib/task-queue.js';

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -1,6 +1,6 @@
 export { default as onExit } from './lib/on-exit.js';
 export { default as execScript } from './lib/exec-script.js';
 export { default as launchFromCli } from './lib/launch-from-cli.js';
-export { default as LogManager, Logger, LogOptions } from './lib/log-manager.js';
+export { default as LogManager, Logger } from './lib/log-manager.js';
 export { default as ConfigManager } from './lib/config-manager.js';
 export { default as TaskQueue, TaskQueueOptions, Task } from './lib/task-queue.js';

--- a/packages/utils/lib/config-manager.js
+++ b/packages/utils/lib/config-manager.js
@@ -31,7 +31,7 @@ export class ConfigManager {
 	 * @template T
 	 * @param {Array<string>} paths 
 	 * @param {ImportMeta?} importMeta The import.meta property of the file at your base directory.
-	 * @returns {Promise<T | null>} The parsed config object or null if none can be found
+	 * @returns {Promise<Partial<T> | null>} The parsed config object or null if none can be found
 	 */
 	static async importJsConfig(paths, importMeta = null) {
 		const __dirname = ConfigManager.getProcessDirname(importMeta);

--- a/packages/utils/lib/launch-from-cli.js
+++ b/packages/utils/lib/launch-from-cli.js
@@ -10,6 +10,7 @@ import { hideBin } from 'yargs/helpers';
  * script was called directly. If it was included in another script, this
  * function will return a rejected promise with no error.
  * 
+ * @template T config type
  * @param {ImportMeta} importMeta Pass the import.meta property from your script here
  * @param {object} [options]
  * @param {object} [options.userConfig] Optional user config to be merged with the loaded config
@@ -47,6 +48,9 @@ export const launchFromCli = async (importMeta, {
 
 	const parsedArgv = await argv.parse();
 
+	/**
+	 * @type {ConfigManager<T>}
+	 */
 	const configManager = new ConfigManager();
 	
 	await configManager.loadConfig(userConfig, parsedArgv.config);

--- a/packages/utils/lib/launch-from-cli.js
+++ b/packages/utils/lib/launch-from-cli.js
@@ -53,6 +53,7 @@ export const launchFromCli = async (importMeta, {
 	 */
 	const configManager = new ConfigManager();
 	
+	// @ts-expect-error - pretty much impossible to type parsedArgv so that it can be merged with userConfig, so we'll just ignore the error
 	await configManager.loadConfig({ ...userConfig, ...parsedArgv }, parsedArgv.config);
 	/** @type {any} TODO: figure out where to add this 'logging' property */
 	const config = configManager.getConfig();

--- a/packages/utils/lib/task-queue.js
+++ b/packages/utils/lib/task-queue.js
@@ -3,12 +3,18 @@ import autoBind from 'auto-bind';
 import chalk from 'chalk';
 import { LogManager, Logger } from './log-manager.js';
 
-export class TaskQueueOptions {
-	constructor({
-		concurrency = 1
-	} = {}) {
-		/** @type {number} */
-		this.concurrency = concurrency;
+/**
+ * @typedef TaskQueueOptions
+ * @property {number} [concurrency] defaults to 1
+ */
+
+/**
+ * @param {TaskQueueOptions} [options] 
+ */
+function resolveTaskQueueOptions(options) {
+	return {
+		concurrency: 1,
+		...options
 	};
 }
 
@@ -24,12 +30,12 @@ class TaskQueue {
 	
 	/**
 	 * 
-	 * @param {TaskQueueOptions} config 
+	 * @param {TaskQueueOptions | undefined} config 
 	 * @param {Logger} logger 
 	 */
 	constructor(config, logger) {
 		autoBind(this);
-		this._config = new TaskQueueOptions(config);
+		this._config = resolveTaskQueueOptions(config);
 		this._logger = logger || LogManager.getInstance().getLogger();
 		this._queue = async.queue(this._processTask, this._config.concurrency || 1);
 		this._queue.drain();


### PR DESCRIPTION
Took a pass at adding intellisense to config files via the `defineConfig` method mentioned in #125. This is downstream of #118 and #124.

- narrowed most of the vague types (`any`, `*`, `{}`, and `object`)
- converted classes to JSDoc type definitions
- added functions to apply defaults to high level configs
- added `defineConfig` function exported from the core package, as well as a `defineContentConfig` exported from the content package, and a `defineMonitorConfig` exported from the monitor package

resolves #125 


Intellisense in action here:

![Screenshot 2023-09-18 at 2 20 52 PM](https://github.com/bluecadet/launchpad/assets/30105080/5eb4670c-8c82-416e-bb37-762be0ef11f0)