### PR TITLE
feat(content): retention sweep with ack leases

### DIFF
--- a/.changeset/retention-sweep-ack-leases.md
+++ b/.changeset/retention-sweep-ack-leases.md
@@ -1,0 +1,5 @@
+---
+"@bluecadet/launchpad-content": minor
+---
+
+Add the keep-N retention sweep for versioned output, run at the end of each successful versioned fetch. The retention set is the `keep` newest version dirs by name (default 3), union the manifest's active version, union any version named by a fresh ack lease (`<downloadPath>/acks/<consumerId>.json`, freshness by mtime vs `ackTimeout`, default 30m); everything else under `versions/` is deleted. Deletion is best-effort and idempotent -- a locked dir is left in place and retried on the next sweep. Sweep results (retained/pending-delete counts, per-consumer ack freshness) are tracked on the content plugin's state.

--- a/.changeset/tidy-birds-scheduler-engine.md
+++ b/.changeset/tidy-birds-scheduler-engine.md
@@ -1,0 +1,5 @@
+---
+"@bluecadet/launchpad-scheduler": minor
+---
+
+Add scheduling engine: chained-`setTimeout` interval jobs anchored to run completion, wall-clock cron jobs via `croner`, jitter reroll per fire, `runOnStart`, and `CommandInProgressError` overlap skipping. Jobs now actually dispatch on their configured schedule instead of being inert.

--- a/.changeset/versioned-promotion-pipeline.md
+++ b/.changeset/versioned-promotion-pipeline.md
@@ -1,0 +1,5 @@
+---
+"@bluecadet/launchpad-content": minor
+---
+
+Wire versioned output into the fetch pipeline: under `versioning`, `finalizingStage` moves the staged downloads root whole into `versions/<versionId>/` and atomically swaps `manifest.json` as the sole commit point, emitting `content:version:promoted` right after. `backupStage` and the restore half of `errorRecoveryStage` are silent no-ops under versioning (retained versions are the backup); a failed promotion instead best-effort deletes the orphaned version dir. Opt-in via `versioning` config; no change to default output behavior.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11269,7 +11269,8 @@
         "@bluecadet/launchpad-cli": "3.0.0",
         "@bluecadet/launchpad-content": "3.0.0",
         "@bluecadet/launchpad-controller": "3.0.0",
-        "@bluecadet/launchpad-monitor": "3.0.0"
+        "@bluecadet/launchpad-monitor": "3.0.0",
+        "@bluecadet/launchpad-scheduler": "0.1.0"
       },
       "devDependencies": {
         "@bluecadet/launchpad-tsconfig": "0.1.0"
@@ -11324,6 +11325,7 @@
       "license": "ISC",
       "dependencies": {
         "@bluecadet/launchpad-utils": "~3.0.0",
+        "croner": "^10.0.1",
         "neverthrow": "^8.2.0",
         "zod": "^4.3.6"
       },
@@ -11334,6 +11336,25 @@
       },
       "engines": {
         "node": ">=23"
+      }
+    },
+    "packages/scheduler/node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "packages/testing": {

--- a/packages/content/src/__tests__/acks.test.ts
+++ b/packages/content/src/__tests__/acks.test.ts
@@ -1,0 +1,139 @@
+import { createMockLogger } from "@bluecadet/launchpad-testing/test-utils.ts";
+import { vol } from "memfs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getAckFilePath, getAcksDirPath, readAckLeases } from "../acks.js";
+
+const ACK_TIMEOUT_MS = 30 * 60 * 1000;
+
+describe("acks", () => {
+	beforeEach(() => {
+		vol.reset();
+	});
+
+	afterEach(() => {
+		vol.reset();
+	});
+
+	describe("readAckLeases", () => {
+		it("returns an empty list when acks/ does not exist", async () => {
+			vol.mkdirSync("/downloads", { recursive: true });
+			const logger = createMockLogger();
+
+			const leases = (await readAckLeases("/downloads", ACK_TIMEOUT_MS, logger))._unsafeUnwrap();
+
+			expect(leases).toEqual([]);
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it("returns an empty list when acks/ is empty", async () => {
+			vol.mkdirSync(getAcksDirPath("/downloads"), { recursive: true });
+			const logger = createMockLogger();
+
+			const leases = (await readAckLeases("/downloads", ACK_TIMEOUT_MS, logger))._unsafeUnwrap();
+
+			expect(leases).toEqual([]);
+		});
+
+		it("reads a fresh ack lease", async () => {
+			vol.mkdirSync(getAcksDirPath("/downloads"), { recursive: true });
+			vol.writeFileSync(
+				getAckFilePath("/downloads", "kiosk-1"),
+				JSON.stringify({ versionId: "20260714T153045Z" }),
+			);
+			const now = new Date("2026-07-14T15:35:00.000Z");
+			vol.utimesSync(getAckFilePath("/downloads", "kiosk-1"), now, now);
+			const logger = createMockLogger();
+
+			const leases = (
+				await readAckLeases("/downloads", ACK_TIMEOUT_MS, logger, now)
+			)._unsafeUnwrap();
+
+			expect(leases).toEqual([
+				{
+					consumerId: "kiosk-1",
+					versionId: "20260714T153045Z",
+					ackedAt: now,
+					fresh: true,
+				},
+			]);
+		});
+
+		it("marks an ack lease older than ackTimeout as not fresh", async () => {
+			vol.mkdirSync(getAcksDirPath("/downloads"), { recursive: true });
+			vol.writeFileSync(
+				getAckFilePath("/downloads", "kiosk-1"),
+				JSON.stringify({ versionId: "20260714T153045Z" }),
+			);
+			const mtime = new Date("2026-07-14T15:00:00.000Z");
+			vol.utimesSync(getAckFilePath("/downloads", "kiosk-1"), mtime, mtime);
+			const now = new Date(mtime.getTime() + ACK_TIMEOUT_MS + 1000);
+			const logger = createMockLogger();
+
+			const leases = (
+				await readAckLeases("/downloads", ACK_TIMEOUT_MS, logger, now)
+			)._unsafeUnwrap();
+
+			expect(leases).toEqual([
+				{
+					consumerId: "kiosk-1",
+					versionId: "20260714T153045Z",
+					ackedAt: mtime,
+					fresh: false,
+				},
+			]);
+		});
+
+		it("ignores unparseable JSON with a logged warning", async () => {
+			vol.mkdirSync(getAcksDirPath("/downloads"), { recursive: true });
+			vol.writeFileSync(getAckFilePath("/downloads", "kiosk-1"), "{not json");
+			const logger = createMockLogger();
+
+			const leases = (await readAckLeases("/downloads", ACK_TIMEOUT_MS, logger))._unsafeUnwrap();
+
+			expect(leases).toEqual([]);
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("unparseable"));
+		});
+
+		it("ignores a lease missing versionId with a logged warning", async () => {
+			vol.mkdirSync(getAcksDirPath("/downloads"), { recursive: true });
+			vol.writeFileSync(
+				getAckFilePath("/downloads", "kiosk-1"),
+				JSON.stringify({ hello: "world" }),
+			);
+			const logger = createMockLogger();
+
+			const leases = (await readAckLeases("/downloads", ACK_TIMEOUT_MS, logger))._unsafeUnwrap();
+
+			expect(leases).toEqual([]);
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("unparseable"));
+		});
+
+		it("ignores non-.json files in acks/", async () => {
+			vol.mkdirSync(getAcksDirPath("/downloads"), { recursive: true });
+			vol.writeFileSync(`${getAcksDirPath("/downloads")}/.DS_Store`, "junk");
+			const logger = createMockLogger();
+
+			const leases = (await readAckLeases("/downloads", ACK_TIMEOUT_MS, logger))._unsafeUnwrap();
+
+			expect(leases).toEqual([]);
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it("reads multiple consumers independently", async () => {
+			vol.mkdirSync(getAcksDirPath("/downloads"), { recursive: true });
+			vol.writeFileSync(
+				getAckFilePath("/downloads", "kiosk-1"),
+				JSON.stringify({ versionId: "20260714T153045Z" }),
+			);
+			vol.writeFileSync(
+				getAckFilePath("/downloads", "kiosk-2"),
+				JSON.stringify({ versionId: "20260714T163045Z" }),
+			);
+			const logger = createMockLogger();
+
+			const leases = (await readAckLeases("/downloads", ACK_TIMEOUT_MS, logger))._unsafeUnwrap();
+
+			expect(leases.map((lease) => lease.consumerId).sort()).toEqual(["kiosk-1", "kiosk-2"]);
+		});
+	});
+});

--- a/packages/content/src/__tests__/content-state.test.ts
+++ b/packages/content/src/__tests__/content-state.test.ts
@@ -1,10 +1,12 @@
 import { createMockPluginCtx } from "@bluecadet/launchpad-testing/test-utils.ts";
 import { produce } from "immer";
 import { vol } from "memfs";
+import { errAsync } from "neverthrow";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ContentState } from "../content-state.js";
 import { content } from "../launchpad-content.js";
 import { defineSource } from "../source.js";
+import * as FileUtils from "../utils/file-utils.js";
 
 function createTestCtx(cwd?: string) {
 	const baseCtx = createMockPluginCtx(cwd);
@@ -381,6 +383,72 @@ describe("ContentState", () => {
 			state = getState();
 			expect(state.sources["source-1"]).toBeDefined();
 			expect(state.sources["source-1"]?.state).toBe("success");
+		});
+	});
+
+	describe("versioned retention sweep state", () => {
+		it("records retention state after a successful versioned fetch", async () => {
+			const config = {
+				...createBasicConfig(1),
+				versioning: { keep: 1, ackTimeout: 1_800_000 },
+			};
+			const { instance, getState } = await setupContent(config);
+
+			const result = await instance.executeCommand({ type: "content.fetch" });
+			expect(result).toBeOk();
+
+			const state = getState();
+			expect(state.retention).toBeDefined();
+			expect(state.retention?.retainedCount).toBe(1);
+			expect(state.retention?.pendingDeleteCount).toBe(0);
+			expect(state.retention?.acks).toEqual([]);
+			expect(state.retention?.sweptAt).toBeInstanceOf(Date);
+		});
+
+		it("reports a pending-delete version once the retention count is exceeded", async () => {
+			const config = {
+				...createBasicConfig(1),
+				versioning: { keep: 1, ackTimeout: 1_800_000 },
+			};
+
+			// Seed a pre-existing older version + manifest, as if left by a prior fetch. The
+			// upcoming fetch mints a new (newer) version, making this one the sole deletion
+			// candidate under `keep: 1`.
+			vol.mkdirSync("/downloads/versions/20200101T000000Z/source-1", { recursive: true });
+			vol.writeFileSync(
+				"/downloads/manifest.json",
+				JSON.stringify({
+					schemaVersion: 1,
+					versionId: "20200101T000000Z",
+					versionPath: "versions/20200101T000000Z",
+					generatedAt: "2020-01-01T00:00:00.000Z",
+					sources: [{ sourceId: "source-1", path: "source-1" }],
+				}),
+			);
+
+			const { instance, getState } = await setupContent(config);
+
+			const removeSpy = vi
+				.spyOn(FileUtils, "remove")
+				.mockReturnValueOnce(errAsync(new FileUtils.FileUtilsError("locked")));
+
+			const result = await instance.executeCommand({ type: "content.fetch" });
+			expect(result).toBeOk();
+
+			const state = getState();
+			expect(state.retention?.retainedCount).toBe(1);
+			expect(state.retention?.pendingDeleteCount).toBe(1);
+
+			removeSpy.mockRestore();
+		});
+
+		it("leaves retention undefined when versioning is off", async () => {
+			const config = createBasicConfig(1);
+			const { instance, getState } = await setupContent(config);
+
+			await instance.executeCommand({ type: "content.fetch" });
+
+			expect(getState().retention).toBeUndefined();
 		});
 	});
 });

--- a/packages/content/src/__tests__/retention-sweep.test.ts
+++ b/packages/content/src/__tests__/retention-sweep.test.ts
@@ -1,0 +1,237 @@
+import { createMockLogger } from "@bluecadet/launchpad-testing/test-utils.ts";
+import { vol } from "memfs";
+import { errAsync } from "neverthrow";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getAckFilePath, getAcksDirPath } from "../acks.js";
+import { getVersionsDirPath, sweepVersions } from "../retention-sweep.js";
+import * as FileUtils from "../utils/file-utils.js";
+
+const ACK_TIMEOUT_MS = 30 * 60 * 1000;
+const DOWNLOAD_PATH = "/downloads";
+
+function makeVersionDir(versionId: string) {
+	const versionPath = `${getVersionsDirPath(DOWNLOAD_PATH)}/${versionId}`;
+	vol.mkdirSync(`${versionPath}/source1`, { recursive: true });
+	vol.writeFileSync(`${versionPath}/source1/file.json`, "{}");
+	return versionPath;
+}
+
+function writeManifest(activeVersionId: string) {
+	vol.writeFileSync(
+		`${DOWNLOAD_PATH}/manifest.json`,
+		JSON.stringify({
+			schemaVersion: 1,
+			versionId: activeVersionId,
+			versionPath: `versions/${activeVersionId}`,
+			generatedAt: "2026-07-14T15:30:47.000Z",
+			sources: [{ sourceId: "source1", path: "source1" }],
+		}),
+	);
+}
+
+function writeAck(consumerId: string, versionId: string, mtime: Date) {
+	const ackPath = getAckFilePath(DOWNLOAD_PATH, consumerId);
+	vol.mkdirSync(getAcksDirPath(DOWNLOAD_PATH), { recursive: true });
+	vol.writeFileSync(ackPath, JSON.stringify({ versionId }));
+	vol.utimesSync(ackPath, mtime, mtime);
+}
+
+describe("sweepVersions", () => {
+	beforeEach(() => {
+		vol.reset();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vol.reset();
+		vi.restoreAllMocks();
+	});
+
+	it("returns an empty result when versions/ does not exist yet", async () => {
+		vol.mkdirSync(DOWNLOAD_PATH, { recursive: true });
+		const logger = createMockLogger();
+
+		const result = (
+			await sweepVersions(DOWNLOAD_PATH, { keep: 3, ackTimeout: ACK_TIMEOUT_MS }, logger)
+		)._unsafeUnwrap();
+
+		expect(result).toEqual({
+			retainedVersionIds: [],
+			deletedVersionIds: [],
+			pendingDeleteVersionIds: [],
+			acks: [],
+		});
+	});
+
+	it("keeps only the newest N version dirs when there's no active version or acks", async () => {
+		for (const versionId of [
+			"20260101T000000Z",
+			"20260102T000000Z",
+			"20260103T000000Z",
+			"20260104T000000Z",
+			"20260105T000000Z",
+		]) {
+			makeVersionDir(versionId);
+		}
+		const logger = createMockLogger();
+
+		const result = (
+			await sweepVersions(DOWNLOAD_PATH, { keep: 3, ackTimeout: ACK_TIMEOUT_MS }, logger)
+		)._unsafeUnwrap();
+
+		expect(result.retainedVersionIds.sort()).toEqual([
+			"20260103T000000Z",
+			"20260104T000000Z",
+			"20260105T000000Z",
+		]);
+		expect(result.deletedVersionIds.sort()).toEqual(["20260101T000000Z", "20260102T000000Z"]);
+		expect(result.pendingDeleteVersionIds).toEqual([]);
+		expect(vol.existsSync(`${getVersionsDirPath(DOWNLOAD_PATH)}/20260101T000000Z`)).toBe(false);
+		expect(vol.existsSync(`${getVersionsDirPath(DOWNLOAD_PATH)}/20260105T000000Z`)).toBe(true);
+	});
+
+	it("extends retention for the manifest's active version even if older than keep-N", async () => {
+		for (const versionId of [
+			"20260101T000000Z",
+			"20260102T000000Z",
+			"20260103T000000Z",
+			"20260104T000000Z",
+		]) {
+			makeVersionDir(versionId);
+		}
+		writeManifest("20260101T000000Z");
+		const logger = createMockLogger();
+
+		const result = (
+			await sweepVersions(DOWNLOAD_PATH, { keep: 2, ackTimeout: ACK_TIMEOUT_MS }, logger)
+		)._unsafeUnwrap();
+
+		expect(result.retainedVersionIds.sort()).toEqual([
+			"20260101T000000Z",
+			"20260103T000000Z",
+			"20260104T000000Z",
+		]);
+		expect(result.deletedVersionIds).toEqual(["20260102T000000Z"]);
+	});
+
+	it("extends retention for a fresh ack lease outside keep-N", async () => {
+		for (const versionId of ["20260101T000000Z", "20260102T000000Z", "20260103T000000Z"]) {
+			makeVersionDir(versionId);
+		}
+		const now = new Date("2026-07-14T15:35:00.000Z");
+		writeAck("kiosk-1", "20260101T000000Z", now);
+		const logger = createMockLogger();
+
+		const result = (
+			await sweepVersions(DOWNLOAD_PATH, { keep: 1, ackTimeout: ACK_TIMEOUT_MS }, logger, now)
+		)._unsafeUnwrap();
+
+		expect(result.retainedVersionIds.sort()).toEqual(["20260101T000000Z", "20260103T000000Z"]);
+		expect(result.deletedVersionIds).toEqual(["20260102T000000Z"]);
+		expect(result.acks).toEqual([
+			{ consumerId: "kiosk-1", versionId: "20260101T000000Z", ackedAt: now, fresh: true },
+		]);
+	});
+
+	it("does not extend retention for a stale ack lease (dead consumer can never block cleanup past ackTimeout)", async () => {
+		for (const versionId of ["20260101T000000Z", "20260102T000000Z", "20260103T000000Z"]) {
+			makeVersionDir(versionId);
+		}
+		const mtime = new Date("2026-07-14T15:00:00.000Z");
+		writeAck("kiosk-1", "20260101T000000Z", mtime);
+		const now = new Date(mtime.getTime() + ACK_TIMEOUT_MS + 1000);
+		const logger = createMockLogger();
+
+		const result = (
+			await sweepVersions(DOWNLOAD_PATH, { keep: 1, ackTimeout: ACK_TIMEOUT_MS }, logger, now)
+		)._unsafeUnwrap();
+
+		expect(result.retainedVersionIds).toEqual(["20260103T000000Z"]);
+		expect(result.deletedVersionIds.sort()).toEqual(["20260101T000000Z", "20260102T000000Z"]);
+		expect(result.acks[0]?.fresh).toBe(false);
+	});
+
+	it("is pure count-based retention when acks/ is empty", async () => {
+		for (const versionId of ["20260101T000000Z", "20260102T000000Z"]) {
+			makeVersionDir(versionId);
+		}
+		vol.mkdirSync(getAcksDirPath(DOWNLOAD_PATH), { recursive: true });
+		const logger = createMockLogger();
+
+		const result = (
+			await sweepVersions(DOWNLOAD_PATH, { keep: 1, ackTimeout: ACK_TIMEOUT_MS }, logger)
+		)._unsafeUnwrap();
+
+		expect(result.retainedVersionIds).toEqual(["20260102T000000Z"]);
+		expect(result.deletedVersionIds).toEqual(["20260101T000000Z"]);
+	});
+
+	it("ages out crash debris under the same rule as any other version dir (no orphan special-casing)", async () => {
+		// Crash debris from a failed promotion is minted via the same version-id format as any
+		// successful one -- it's just an ordinary, never-referenced dir in `versions/`.
+		makeVersionDir("20260101T000000Z");
+		makeVersionDir("20260102T000000Z"); // never promoted; no manifest entry, no ack
+		makeVersionDir("20260103T000000Z");
+		const logger = createMockLogger();
+
+		const result = (
+			await sweepVersions(DOWNLOAD_PATH, { keep: 1, ackTimeout: ACK_TIMEOUT_MS }, logger)
+		)._unsafeUnwrap();
+
+		expect(result.retainedVersionIds).toEqual(["20260103T000000Z"]);
+		expect(result.deletedVersionIds.sort()).toEqual(["20260101T000000Z", "20260102T000000Z"]);
+	});
+
+	it("leaves a dir eligible next pass and reports it as pending-delete when removal fails", async () => {
+		makeVersionDir("20260101T000000Z");
+		makeVersionDir("20260102T000000Z");
+		makeVersionDir("20260103T000000Z");
+
+		const realRemove = FileUtils.remove;
+		const removeSpy = vi.spyOn(FileUtils, "remove").mockImplementation((dir, options) => {
+			if (dir.endsWith("20260101T000000Z")) {
+				return errAsync(new FileUtils.FileUtilsError("locked"));
+			}
+			return realRemove(dir, options);
+		});
+
+		const logger = createMockLogger();
+
+		const result = (
+			await sweepVersions(DOWNLOAD_PATH, { keep: 1, ackTimeout: ACK_TIMEOUT_MS }, logger)
+		)._unsafeUnwrap();
+
+		expect(result.pendingDeleteVersionIds).toEqual(["20260101T000000Z"]);
+		expect(result.deletedVersionIds).toEqual(["20260102T000000Z"]);
+		expect(vol.existsSync(`${getVersionsDirPath(DOWNLOAD_PATH)}/20260101T000000Z`)).toBe(true);
+		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("20260101T000000Z"));
+
+		removeSpy.mockRestore();
+	});
+
+	it("re-derives eligibility fresh on the next sweep, retrying a pending-delete dir", async () => {
+		makeVersionDir("20260101T000000Z");
+		makeVersionDir("20260102T000000Z");
+		const logger = createMockLogger();
+
+		const realRemove = FileUtils.remove;
+		const removeSpy = vi
+			.spyOn(FileUtils, "remove")
+			.mockImplementationOnce(() => errAsync(new FileUtils.FileUtilsError("locked")))
+			.mockImplementation((dir, options) => realRemove(dir, options));
+
+		const firstPass = (
+			await sweepVersions(DOWNLOAD_PATH, { keep: 1, ackTimeout: ACK_TIMEOUT_MS }, logger)
+		)._unsafeUnwrap();
+		expect(firstPass.pendingDeleteVersionIds).toEqual(["20260101T000000Z"]);
+		expect(vol.existsSync(`${getVersionsDirPath(DOWNLOAD_PATH)}/20260101T000000Z`)).toBe(true);
+
+		const secondPass = (
+			await sweepVersions(DOWNLOAD_PATH, { keep: 1, ackTimeout: ACK_TIMEOUT_MS }, logger)
+		)._unsafeUnwrap();
+		expect(secondPass.deletedVersionIds).toEqual(["20260101T000000Z"]);
+		expect(vol.existsSync(`${getVersionsDirPath(DOWNLOAD_PATH)}/20260101T000000Z`)).toBe(false);
+
+		removeSpy.mockRestore();
+	});
+});

--- a/packages/content/src/acks.ts
+++ b/packages/content/src/acks.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { Logger } from "@bluecadet/launchpad-utils/logger";
+import { okAsync, ResultAsync } from "neverthrow";
+import { z } from "zod";
+import * as FileUtils from "./utils/file-utils.js";
+
+/** Directory under `downloadPath` holding one ack-lease file per consumer. */
+export const ACKS_DIRNAME = "acks";
+
+const ackBodySchema = z.object({
+	versionId: z.string().min(1),
+});
+
+/**
+ * An ack lease read from `acks/<consumerId>.json`. Freshness is derived from the file's
+ * mtime vs `ackTimeout` -- both launchpad and the writing consumer read the same OS clock, so
+ * there's no timestamp field in the body to format or drift.
+ */
+export type AckLease = {
+	consumerId: string;
+	versionId: string;
+	ackedAt: Date;
+	fresh: boolean;
+};
+
+export function getAcksDirPath(downloadPath: string): string {
+	return path.join(downloadPath, ACKS_DIRNAME);
+}
+
+export function getAckFilePath(downloadPath: string, consumerId: string): string {
+	return path.join(getAcksDirPath(downloadPath), `${consumerId}.json`);
+}
+
+function consumerIdFromFilename(filename: string): string {
+	return filename.slice(0, -".json".length);
+}
+
+function readAckLease(
+	acksDir: string,
+	filename: string,
+	ackTimeout: number,
+	logger: Pick<Logger, "warn">,
+	now: Date,
+): ResultAsync<AckLease | undefined, never> {
+	const filePath = path.join(acksDir, filename);
+
+	return ResultAsync.fromPromise(
+		Promise.all([fs.promises.readFile(filePath, "utf8"), fs.promises.stat(filePath)]),
+		(error) => error,
+	)
+		.map(([raw, stats]) => {
+			let json: unknown;
+			try {
+				json = JSON.parse(raw);
+			} catch {
+				logger.warn(`Ignoring unparseable ack lease at ${filePath}: invalid JSON.`);
+				return undefined;
+			}
+
+			const parsed = ackBodySchema.safeParse(json);
+			if (!parsed.success) {
+				logger.warn(`Ignoring unparseable ack lease at ${filePath}: ${parsed.error.message}`);
+				return undefined;
+			}
+
+			return {
+				consumerId: consumerIdFromFilename(filename),
+				versionId: parsed.data.versionId,
+				ackedAt: stats.mtime,
+				fresh: now.getTime() - stats.mtime.getTime() <= ackTimeout,
+			};
+		})
+		.orElse((error) => {
+			logger.warn(
+				`Ignoring unreadable ack lease at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return okAsync(undefined);
+		});
+}
+
+/**
+ * Reads every `acks/<consumerId>.json` lease under `downloadPath`. Never fails: a missing
+ * `acks/` directory resolves to an empty list (pure count-based retention), and an
+ * unparseable or unreadable lease is dropped with a logged warning rather than aborting the
+ * whole read -- the sweep's keep-N backstop still protects retention regardless.
+ */
+export function readAckLeases(
+	downloadPath: string,
+	ackTimeout: number,
+	logger: Pick<Logger, "warn">,
+	now: Date = new Date(),
+): ResultAsync<AckLease[], never> {
+	const acksDir = getAcksDirPath(downloadPath);
+
+	return FileUtils.pathExists(acksDir).andThen((exists) => {
+		if (!exists) {
+			return okAsync<AckLease[]>([]);
+		}
+
+		return FileUtils.listDir(acksDir)
+			.orElse((error) => {
+				logger.warn(`Failed to list ack leases at ${acksDir}: ${error.message}`);
+				return okAsync<string[]>([]);
+			})
+			.andThen((filenames) => {
+				const jsonFilenames = filenames.filter((filename) => filename.endsWith(".json"));
+				return ResultAsync.combine(
+					jsonFilenames.map((filename) => readAckLease(acksDir, filename, ackTimeout, logger, now)),
+				);
+			})
+			.map((leases) => leases.filter((lease): lease is AckLease => lease !== undefined));
+	});
+}

--- a/packages/content/src/content-events.ts
+++ b/packages/content/src/content-events.ts
@@ -28,6 +28,13 @@ export type ContentEvents = {
 		source?: string;
 	};
 
+	/** Emitted immediately after the manifest swap under versioned output mode. */
+	"content:version:promoted": {
+		versionId: string;
+		versionPath: string;
+		generatedAt: string;
+	};
+
 	// Source-specific events
 	"content:source:start": {
 		sourceId: string;

--- a/packages/content/src/content-state.ts
+++ b/packages/content/src/content-state.ts
@@ -2,7 +2,9 @@
  * Content plugin state exported for public API.
  */
 
+import type { AckLease } from "./acks.js";
 import type { ContentError } from "./content-transform.js";
+import type { SweepResult } from "./retention-sweep.js";
 // need to import so declaration merging works
 import "@bluecadet/launchpad-utils/types";
 
@@ -59,6 +61,9 @@ export type ContentPhase =
 			restored: boolean;
 	  }
 	| {
+			phase: "sweeping-versions";
+	  }
+	| {
 			phase: "error";
 			error: ContentError;
 			restored: boolean;
@@ -67,8 +72,20 @@ export type ContentPhase =
 			phase: "clearing-temp";
 	  };
 
+/**
+ * Result of the most recent versioned-output retention sweep. Undefined until the first
+ * versioned fetch completes, or permanently under non-versioned output.
+ */
+export type RetentionState = {
+	retainedCount: number;
+	pendingDeleteCount: number;
+	acks: AckLease[];
+	sweptAt: Date;
+};
+
 export type ContentState = ContentPhase & {
 	sources: Record<string, SourceFetchState>;
+	retention?: RetentionState;
 };
 
 declare module "@bluecadet/launchpad-utils/types" {
@@ -146,6 +163,17 @@ export class ContentStateManager {
 					restored: true,
 				};
 			}
+		});
+	}
+
+	recordSweep(result: SweepResult, sweptAt: Date = new Date()): void {
+		this.updateState((draft) => {
+			draft.retention = {
+				retainedCount: result.retainedVersionIds.length,
+				pendingDeleteCount: result.pendingDeleteVersionIds.length,
+				acks: result.acks,
+				sweptAt,
+			};
 		});
 	}
 }

--- a/packages/content/src/fetching/__tests__/fetch-stages.test.ts
+++ b/packages/content/src/fetching/__tests__/fetch-stages.test.ts
@@ -16,6 +16,7 @@ import {
 	fetchSourcesStage,
 	finalizingStage,
 	runTransformsStage,
+	sweepStage,
 } from "../fetch-stages.js";
 import {
 	createMockContentConfig,
@@ -675,6 +676,43 @@ describe("Fetch Stages", () => {
 					writeManifestSpy.mockRestore();
 				}
 			});
+		});
+	});
+
+	describe("sweepStage", () => {
+		it("should be a no-op when versioning is off", async () => {
+			vol.mkdirSync("/downloads/versions/oldVersion", { recursive: true });
+			const context = createMockFetchContext({
+				config: createMockContentConfig({ versioning: false }),
+			});
+
+			const result = await sweepStage(context);
+
+			expect(result).toBeOk();
+			expect(result._unsafeUnwrap()).toBeUndefined();
+			expect(vol.existsSync("/downloads/versions/oldVersion")).toBe(true);
+		});
+
+		it("should sweep versions/ under the published download path when versioning is on", async () => {
+			vol.mkdirSync("/downloads/versions/20260101T000000Z", { recursive: true });
+			vol.mkdirSync("/downloads/versions/20260102T000000Z", { recursive: true });
+			vol.mkdirSync("/downloads/versions/20260103T000000Z", { recursive: true });
+
+			const context = createMockFetchContext({
+				config: createMockContentConfig({ versioning: { keep: 1, ackTimeout: 1_800_000 } }),
+			});
+
+			const result = await sweepStage(context);
+
+			expect(result).toBeOk();
+			const sweepResult = result._unsafeUnwrap();
+			expect(sweepResult?.retainedVersionIds).toEqual(["20260103T000000Z"]);
+			expect(sweepResult?.deletedVersionIds.sort()).toEqual([
+				"20260101T000000Z",
+				"20260102T000000Z",
+			]);
+			expect(vol.existsSync("/downloads/versions/20260101T000000Z")).toBe(false);
+			expect(vol.existsSync("/downloads/versions/20260103T000000Z")).toBe(true);
 		});
 	});
 

--- a/packages/content/src/fetching/__tests__/fetch-stages.test.ts
+++ b/packages/content/src/fetching/__tests__/fetch-stages.test.ts
@@ -159,6 +159,158 @@ describe("Fetch Stages", () => {
 			expect(result).toBeOk();
 			expect(vol.existsSync("/temp/runs/test-run/downloads/nonexistent")).toBe(true);
 		});
+
+		describe("under versioning", () => {
+			it("should seed each source from the manifest's active version, resolved via sources[].path", async () => {
+				vol.mkdirSync("/downloads/versions/activeVersion/test1-dir", { recursive: true });
+				vol.mkdirSync("/downloads/versions/activeVersion/test2-dir", { recursive: true });
+				vol.writeFileSync("/downloads/versions/activeVersion/test1-dir/.keep", "");
+				vol.writeFileSync("/downloads/versions/activeVersion/test2-dir/.keep", "");
+				vol.writeFileSync(
+					"/downloads/manifest.json",
+					JSON.stringify({
+						schemaVersion: 1,
+						versionId: "activeVersion",
+						versionPath: "versions/activeVersion",
+						generatedAt: "2026-01-01T00:00:00.000Z",
+						sources: [
+							{ sourceId: "test1", path: "test1-dir" },
+							{ sourceId: "test2", path: "test2-dir" },
+						],
+					}),
+				);
+
+				const context = createMockFetchContext({
+					config: createMockContentConfig({
+						keep: [".keep"],
+						versioning: { keep: 3, ackTimeout: 1_800_000 },
+					}),
+					sources: [
+						defineSource({ id: "test1", fetch: () => [] }),
+						defineSource({ id: "test2", fetch: () => [] }),
+					],
+				});
+
+				const result = await clearOldDataStage(context);
+
+				expect(result).toBeOk();
+				expect(vol.existsSync("/temp/runs/test-run/downloads/test1/.keep")).toBe(true);
+				expect(vol.existsSync("/temp/runs/test-run/downloads/test2/.keep")).toBe(true);
+			});
+
+			it("should seed empty and warn when no manifest exists yet", async () => {
+				vol.mkdirSync("/downloads", { recursive: true });
+
+				const context = createMockFetchContext({
+					config: createMockContentConfig({
+						keep: [".keep"],
+						versioning: { keep: 3, ackTimeout: 1_800_000 },
+					}),
+					sources: [defineSource({ id: "test", fetch: () => [] })],
+				});
+
+				const result = await clearOldDataStage(context);
+
+				expect(result).toBeOk();
+				expect(vol.existsSync("/temp/runs/test-run/downloads/test")).toBe(true);
+				expect(vol.readdirSync("/temp/runs/test-run/downloads/test")).toEqual([]);
+				expect(context.logger.warn).toHaveBeenCalledWith(
+					expect.stringContaining("No manifest found"),
+				);
+			});
+
+			it("should seed empty and warn when the manifest's version dir is missing", async () => {
+				vol.mkdirSync("/downloads", { recursive: true });
+				vol.writeFileSync(
+					"/downloads/manifest.json",
+					JSON.stringify({
+						schemaVersion: 1,
+						versionId: "goneVersion",
+						versionPath: "versions/goneVersion",
+						generatedAt: "2026-01-01T00:00:00.000Z",
+						sources: [{ sourceId: "test", path: "test" }],
+					}),
+				);
+
+				const context = createMockFetchContext({
+					config: createMockContentConfig({
+						keep: [".keep"],
+						versioning: { keep: 3, ackTimeout: 1_800_000 },
+					}),
+					sources: [defineSource({ id: "test", fetch: () => [] })],
+				});
+
+				const result = await clearOldDataStage(context);
+
+				expect(result).toBeOk();
+				expect(vol.existsSync("/temp/runs/test-run/downloads/test")).toBe(true);
+				expect(vol.readdirSync("/temp/runs/test-run/downloads/test")).toEqual([]);
+				expect(context.logger.warn).toHaveBeenCalledWith(
+					expect.stringContaining("Active version directory not found"),
+				);
+			});
+
+			it("should seed empty and warn when the active version has no entry for a source", async () => {
+				vol.mkdirSync("/downloads/versions/activeVersion", { recursive: true });
+				vol.writeFileSync(
+					"/downloads/manifest.json",
+					JSON.stringify({
+						schemaVersion: 1,
+						versionId: "activeVersion",
+						versionPath: "versions/activeVersion",
+						generatedAt: "2026-01-01T00:00:00.000Z",
+						sources: [{ sourceId: "other", path: "other" }],
+					}),
+				);
+
+				const context = createMockFetchContext({
+					config: createMockContentConfig({
+						keep: [".keep"],
+						versioning: { keep: 3, ackTimeout: 1_800_000 },
+					}),
+					sources: [defineSource({ id: "test", fetch: () => [] })],
+				});
+
+				const result = await clearOldDataStage(context);
+
+				expect(result).toBeOk();
+				expect(vol.existsSync("/temp/runs/test-run/downloads/test")).toBe(true);
+				expect(vol.readdirSync("/temp/runs/test-run/downloads/test")).toEqual([]);
+				expect(context.logger.warn).toHaveBeenCalledWith(
+					expect.stringContaining("has no entry for source test"),
+				);
+			});
+
+			it("should never seed from an orphan dir newer than the active version", async () => {
+				vol.mkdirSync("/downloads/versions/activeVersion/test", { recursive: true });
+				vol.writeFileSync("/downloads/versions/activeVersion/test/.keep", "active");
+				vol.mkdirSync("/downloads/versions/zzz-newer-orphan/test", { recursive: true });
+				vol.writeFileSync("/downloads/versions/zzz-newer-orphan/test/.keep", "orphan");
+				vol.writeFileSync(
+					"/downloads/manifest.json",
+					JSON.stringify({
+						schemaVersion: 1,
+						versionId: "activeVersion",
+						versionPath: "versions/activeVersion",
+						generatedAt: "2026-01-01T00:00:00.000Z",
+						sources: [{ sourceId: "test", path: "test" }],
+					}),
+				);
+
+				const context = createMockFetchContext({
+					config: createMockContentConfig({
+						keep: [".keep"],
+						versioning: { keep: 3, ackTimeout: 1_800_000 },
+					}),
+					sources: [defineSource({ id: "test", fetch: () => [] })],
+				});
+
+				const result = await clearOldDataStage(context);
+
+				expect(result).toBeOk();
+				expect(vol.readFileSync("/temp/runs/test-run/downloads/test/.keep", "utf8")).toBe("active");
+			});
+		});
 	});
 
 	describe("fetchSourcesStage", () => {

--- a/packages/content/src/fetching/__tests__/fetch-stages.test.ts
+++ b/packages/content/src/fetching/__tests__/fetch-stages.test.ts
@@ -1,7 +1,9 @@
+import path from "node:path";
 import { vol } from "memfs";
 import { errAsync, ok, okAsync } from "neverthrow";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ContentError } from "../../content-transform.js";
+import * as ManifestUtils from "../../manifest.js";
 import { defineSource } from "../../source.js";
 import * as FileUtils from "../../utils/file-utils.js";
 import {
@@ -84,6 +86,24 @@ describe("Fetch Stages", () => {
 
 			expect(vol.existsSync("/backups/test/file.json")).toBe(true);
 			expect(vol.readFileSync("/backups/test/file.json", "utf8")).toBe('{"data":"test"}');
+		});
+
+		it("should skip backup when versioning is enabled, even if backupAndRestore is true", async () => {
+			vol.mkdirSync("/downloads/test", { recursive: true });
+			vol.writeFileSync("/downloads/test/file.json", '{"data":"test"}');
+
+			const context = createMockFetchContext({
+				config: createMockContentConfig({
+					backupAndRestore: true,
+					versioning: { keep: 3, ackTimeout: 1_800_000 },
+				}),
+				sources: [defineSource({ id: "test", fetch: () => [] })],
+			});
+
+			const result = await backupStage(context);
+
+			expect(result).toBeOk();
+			expect(vol.existsSync("/backups/test/file.json")).toBe(false);
 		});
 	});
 
@@ -324,6 +344,186 @@ describe("Fetch Stages", () => {
 
 			expect(result).toBeErr();
 		});
+
+		describe("under versioning", () => {
+			it("should move the staged root into versions/<versionId>, swap the manifest, and emit the promoted event after the swap", async () => {
+				vol.mkdirSync("/temp/runs/test-run/downloads/source1", { recursive: true });
+				vol.mkdirSync("/temp/runs/test-run/downloads/source2", { recursive: true });
+				vol.writeFileSync("/temp/runs/test-run/downloads/source1/file.json", '{"id":1}');
+				vol.writeFileSync("/temp/runs/test-run/downloads/source2/file.json", '{"id":2}');
+
+				vol.mkdirSync("/downloads/versions/oldVersion/source1", { recursive: true });
+				vol.writeFileSync("/downloads/versions/oldVersion/source1/file.json", '{"id":"old"}');
+				vol.writeFileSync(
+					"/downloads/manifest.json",
+					JSON.stringify({
+						schemaVersion: 1,
+						versionId: "oldVersion",
+						versionPath: "versions/oldVersion",
+						generatedAt: "2026-01-01T00:00:00.000Z",
+						sources: [{ sourceId: "source1", path: "source1" }],
+					}),
+				);
+
+				const context = createMockFetchContext({
+					config: createMockContentConfig({ versioning: { keep: 3, ackTimeout: 1_800_000 } }),
+					sources: [
+						defineSource({ id: "source1", fetch: () => [] }),
+						defineSource({ id: "source2", fetch: () => [] }),
+					],
+				});
+
+				const result = await finalizingStage(context);
+
+				expect(result).toBeOk();
+
+				const manifest = JSON.parse(vol.readFileSync("/downloads/manifest.json", "utf8") as string);
+				expect(manifest.schemaVersion).toBe(1);
+				expect(manifest.versionId).toMatch(/^\d{8}T\d{6}Z$/);
+				expect(manifest.versionPath).toBe(`versions/${manifest.versionId}`);
+				expect(manifest.sources).toEqual([
+					{ sourceId: "source1", path: "source1" },
+					{ sourceId: "source2", path: "source2" },
+				]);
+
+				expect(vol.existsSync(`/downloads/${manifest.versionPath}/source1/file.json`)).toBe(true);
+				expect(vol.existsSync(`/downloads/${manifest.versionPath}/source2/file.json`)).toBe(true);
+
+				// Previously active version is untouched
+				expect(vol.readFileSync("/downloads/versions/oldVersion/source1/file.json", "utf8")).toBe(
+					'{"id":"old"}',
+				);
+
+				const events = context.eventBus.getEmittedEvents();
+				const promotedIndex = events.findIndex((e) => e.event === "content:version:promoted");
+				const doneIndex = events.findIndex((e) => e.event === "content:fetch:done");
+				expect(promotedIndex).toBeGreaterThanOrEqual(0);
+				expect(doneIndex).toBeGreaterThan(promotedIndex);
+
+				expect(events[promotedIndex].data).toEqual({
+					versionId: manifest.versionId,
+					versionPath: manifest.versionPath,
+					generatedAt: manifest.generatedAt,
+				});
+			});
+
+			it("should not delete the just-committed version if error recovery runs afterward for an unrelated failure", async () => {
+				vol.mkdirSync("/temp/runs/test-run/downloads/source1", { recursive: true });
+				vol.writeFileSync("/temp/runs/test-run/downloads/source1/file.json", '{"id":1}');
+
+				const context = createMockFetchContext({
+					config: createMockContentConfig({ versioning: { keep: 3, ackTimeout: 1_800_000 } }),
+					sources: [defineSource({ id: "source1", fetch: () => [] })],
+				});
+
+				const result = await finalizingStage(context);
+				expect(result).toBeOk();
+
+				const manifestBefore = JSON.parse(
+					vol.readFileSync("/downloads/manifest.json", "utf8") as string,
+				);
+
+				// Simulate a later, unrelated stage (e.g. cleanupStage) failing after promotion
+				// already committed, which routes through the same error-recovery path.
+				await errorRecoveryStage(context, new ContentError("unrelated later-stage failure"));
+
+				expect(vol.existsSync(`/downloads/${manifestBefore.versionPath}/source1/file.json`)).toBe(
+					true,
+				);
+				expect(JSON.parse(vol.readFileSync("/downloads/manifest.json", "utf8") as string)).toEqual(
+					manifestBefore,
+				);
+			});
+
+			it("should leave the active version and manifest untouched, and best-effort delete the orphan, when promotion fails before the swap", async () => {
+				vol.mkdirSync("/temp/runs/test-run/downloads/source1", { recursive: true });
+				vol.writeFileSync("/temp/runs/test-run/downloads/source1/file.json", '{"id":1}');
+
+				vol.mkdirSync("/downloads/versions/oldVersion/source1", { recursive: true });
+				vol.writeFileSync("/downloads/versions/oldVersion/source1/file.json", '{"id":"old"}');
+				const originalManifestJson = JSON.stringify({
+					schemaVersion: 1,
+					versionId: "oldVersion",
+					versionPath: "versions/oldVersion",
+					generatedAt: "2026-01-01T00:00:00.000Z",
+					sources: [{ sourceId: "source1", path: "source1" }],
+				});
+				vol.writeFileSync("/downloads/manifest.json", originalManifestJson);
+
+				const moveSpy = vi
+					.spyOn(FileUtils, "move")
+					.mockReturnValue(errAsync(new FileUtils.FileUtilsError("promotion failed")));
+
+				try {
+					const context = createMockFetchContext({
+						config: createMockContentConfig({ versioning: { keep: 3, ackTimeout: 1_800_000 } }),
+						sources: [defineSource({ id: "source1", fetch: () => [] })],
+					});
+
+					const result = await finalizingStage(context);
+					expect(result).toBeErr();
+
+					expect(vol.readFileSync("/downloads/manifest.json", "utf8")).toBe(originalManifestJson);
+					expect(vol.readFileSync("/downloads/versions/oldVersion/source1/file.json", "utf8")).toBe(
+						'{"id":"old"}',
+					);
+
+					const error = result._unsafeUnwrapErr();
+					const recovery = await errorRecoveryStage(context, error);
+					expect(recovery).toBeOk();
+					expect(recovery._unsafeUnwrap().restoredSourceIds).toEqual([]);
+					expect(vol.existsSync(context.attemptedVersionPath as string)).toBe(false);
+				} finally {
+					moveSpy.mockRestore();
+				}
+			});
+
+			it("should leave an orphan dir and nothing else when the crash happens between the move and the manifest swap", async () => {
+				vol.mkdirSync("/temp/runs/test-run/downloads/source1", { recursive: true });
+				vol.writeFileSync("/temp/runs/test-run/downloads/source1/file.json", '{"id":1}');
+
+				vol.mkdirSync("/downloads/versions/oldVersion/source1", { recursive: true });
+				vol.writeFileSync("/downloads/versions/oldVersion/source1/file.json", '{"id":"old"}');
+				const originalManifestJson = JSON.stringify({
+					schemaVersion: 1,
+					versionId: "oldVersion",
+					versionPath: "versions/oldVersion",
+					generatedAt: "2026-01-01T00:00:00.000Z",
+					sources: [{ sourceId: "source1", path: "source1" }],
+				});
+				vol.writeFileSync("/downloads/manifest.json", originalManifestJson);
+
+				const writeManifestSpy = vi
+					.spyOn(ManifestUtils, "writeManifest")
+					.mockReturnValue(errAsync(new ManifestUtils.ManifestError("simulated crash")));
+
+				try {
+					const context = createMockFetchContext({
+						config: createMockContentConfig({ versioning: { keep: 3, ackTimeout: 1_800_000 } }),
+						sources: [defineSource({ id: "source1", fetch: () => [] })],
+					});
+
+					const result = await finalizingStage(context);
+					expect(result).toBeErr();
+
+					// Active version and manifest are untouched
+					expect(vol.readFileSync("/downloads/manifest.json", "utf8")).toBe(originalManifestJson);
+					expect(vol.readFileSync("/downloads/versions/oldVersion/source1/file.json", "utf8")).toBe(
+						'{"id":"old"}',
+					);
+
+					// The move completed (orphan dir left behind); recovery never ran
+					const orphanPath = context.attemptedVersionPath as string;
+					expect(vol.existsSync(orphanPath)).toBe(true);
+					expect(vol.existsSync(path.join(orphanPath, "source1", "file.json"))).toBe(true);
+
+					const versionDirs = vol.readdirSync("/downloads/versions");
+					expect(versionDirs.sort()).toEqual(["oldVersion", path.basename(orphanPath)].sort());
+				} finally {
+					writeManifestSpy.mockRestore();
+				}
+			});
+		});
 	});
 
 	describe("errorRecoveryStage", () => {
@@ -393,6 +593,48 @@ describe("Fetch Stages", () => {
 				expect(result._unsafeUnwrapErr()).toBeInstanceOf(ContentRecoveryError);
 			} finally {
 				copySpy.mockRestore();
+			}
+		});
+
+		it("should skip restore and best-effort delete the orphaned version dir under versioning", async () => {
+			vol.mkdirSync("/downloads/versions/newVersion/test", { recursive: true });
+			vol.writeFileSync("/downloads/versions/newVersion/test/file.json", "{}");
+
+			const context = createMockFetchContext({
+				config: createMockContentConfig({ versioning: { keep: 3, ackTimeout: 1_800_000 } }),
+				sources: [defineSource({ id: "test", fetch: () => [] })],
+			});
+			context.attemptedVersionPath = "/downloads/versions/newVersion";
+
+			const error = new ContentError("Test error");
+			const result = await errorRecoveryStage(context, error);
+
+			expect(result).toBeOk();
+			expect(result._unsafeUnwrap().restoredSourceIds).toEqual([]);
+			expect(vol.existsSync("/downloads/versions/newVersion")).toBe(false);
+		});
+
+		it("should log a warning and continue when the orphaned version dir can't be removed", async () => {
+			const context = createMockFetchContext({
+				config: createMockContentConfig({ versioning: { keep: 3, ackTimeout: 1_800_000 } }),
+				sources: [defineSource({ id: "test", fetch: () => [] })],
+			});
+			context.attemptedVersionPath = "/downloads/versions/newVersion";
+
+			const removeSpy = vi
+				.spyOn(FileUtils, "remove")
+				.mockReturnValue(errAsync(new FileUtils.FileUtilsError("locked")));
+
+			try {
+				const result = await errorRecoveryStage(context, new ContentError("Test error"));
+
+				expect(result).toBeOk();
+				expect(result._unsafeUnwrap().restoredSourceIds).toEqual([]);
+				expect(context.logger.warn).toHaveBeenCalledWith(
+					expect.stringContaining("Failed to remove orphaned version directory"),
+				);
+			} finally {
+				removeSpy.mockRestore();
 			}
 		});
 	});

--- a/packages/content/src/fetching/fetch-context.ts
+++ b/packages/content/src/fetching/fetch-context.ts
@@ -47,4 +47,11 @@ export type FetchStageContext = {
 
 	// Resolved sources to fetch (set by pipeline orchestrator)
 	sources: Array<ContentSource>;
+
+	/**
+	 * Absolute path of the version directory this run attempted to promote into, under
+	 * versioned output mode. Set by `finalizingStage` before the move so that
+	 * `errorRecoveryStage` can best-effort delete an orphaned version dir on failure.
+	 */
+	attemptedVersionPath?: string;
 };

--- a/packages/content/src/fetching/fetch-stages.ts
+++ b/packages/content/src/fetching/fetch-stages.ts
@@ -5,6 +5,7 @@
  * Stages are composed in LaunchpadContent._executeFetchPipeline.
  */
 
+import path from "node:path";
 import { ensureError } from "@bluecadet/launchpad-utils/errors";
 import chalk from "chalk";
 import { err, errAsync, okAsync, ResultAsync } from "neverthrow";
@@ -13,6 +14,8 @@ import {
 	type ContentTransform,
 	type ContentTransformContext,
 } from "../content-transform.js";
+import type { Manifest } from "../manifest.js";
+import * as ManifestUtils from "../manifest.js";
 import type { ContentSource } from "../source.js";
 import { FetchLogger } from "../utils/fetch-logger.js";
 import * as FileUtils from "../utils/file-utils.js";
@@ -104,6 +107,70 @@ function promoteStagedRootEntries(context: FetchStageContext): ResultAsync<void,
 		);
 }
 
+/**
+ * Promotes the entire staged downloads root into a fresh `versions/<versionId>/` directory
+ * in a single move, then atomically swaps the manifest to point at it. The manifest rename
+ * is the sole commit point; any failure before it leaves the active version untouched.
+ */
+function promoteVersioned(context: FetchStageContext): ResultAsync<void, ContentError> {
+	const stagedRoot = context.paths.getStagedDownloadPath();
+	const publishedRoot = context.paths.getPublishedDownloadPath();
+	const versionId = ManifestUtils.mintVersionId();
+	const versionRelativePath = path.posix.join("versions", versionId);
+	const versionAbsolutePath = path.join(publishedRoot, "versions", versionId);
+
+	context.attemptedVersionPath = versionAbsolutePath;
+
+	return FileUtils.pathExists(stagedRoot)
+		.andThen((exists) => {
+			if (!exists) {
+				return okAsync(undefined);
+			}
+
+			return FileUtils.move(stagedRoot, versionAbsolutePath).andThen(() => {
+				const generatedAt = new Date().toISOString();
+				const manifest: Manifest = {
+					schemaVersion: ManifestUtils.MANIFEST_SCHEMA_VERSION,
+					versionId,
+					versionPath: versionRelativePath,
+					generatedAt,
+					sources: context.sources.map((source) => ({ sourceId: source.id, path: source.id })),
+				};
+
+				return ManifestUtils.writeManifest(publishedRoot, manifest).andTee(() => {
+					// Committed: clear the attempt marker so a later, unrelated stage failure
+					// (e.g. cleanupStage) can't cause error recovery to delete the now-active,
+					// manifest-referenced version.
+					context.attemptedVersionPath = undefined;
+					context.eventBus?.emit("content:version:promoted", {
+						versionId,
+						versionPath: versionRelativePath,
+						generatedAt,
+					});
+				});
+			});
+		})
+		.mapErr((error) => new ContentError("Failed to promote versioned output", { cause: error }));
+}
+
+/**
+ * Best-effort delete of the version dir this run tried to create, for the versioned-output
+ * error path. The retention sweep is the backstop for anything left behind by a failed delete.
+ */
+function cleanupOrphanedVersion(context: FetchStageContext): ResultAsync<void, never> {
+	const versionPath = context.attemptedVersionPath;
+	if (!versionPath) {
+		return okAsync(undefined);
+	}
+
+	return FileUtils.remove(versionPath).orElse((error) => {
+		context.logger.warn(
+			`Failed to remove orphaned version directory ${versionPath}: ${error.message}`,
+		);
+		return okAsync(undefined);
+	});
+}
+
 export type { FetchStageContext } from "./fetch-context.js";
 
 /**
@@ -138,7 +205,10 @@ export class ContentRecoveryError extends ContentError {
  * Stage 2: Back up existing downloads (optional).
  */
 export function backupStage(context: FetchStageContext): ResultAsync<void, ContentError> {
-	const backupRequired = context.config.backupAndRestore;
+	// Superseded under versioning: retained version dirs are strictly better backups, and the
+	// active version is never touched mid-fetch, so there's nothing to protect. Silent, since
+	// `backupAndRestore` defaults to true and a warning would fire for every versioned config.
+	const backupRequired = context.config.backupAndRestore && !context.config.versioning;
 	if (!backupRequired) {
 		return okAsync(undefined);
 	}
@@ -363,6 +433,10 @@ export function finalizingStage(context: FetchStageContext): ResultAsync<void, C
 				return okAsync(undefined);
 			}
 
+			if (context.config.versioning) {
+				return promoteVersioned(context);
+			}
+
 			return ResultAsync.combine(
 				context.sources.map((source) => promoteStagedSourceDirectory(context, source.id)),
 			)
@@ -387,6 +461,12 @@ export const errorRecoveryStage = (
 	context.logger.error("Error in content fetch process. Running recovery steps...");
 
 	context.eventBus?.emit("content:fetch:error", { error });
+
+	// Superseded under versioning: the active version was never touched, so there's nothing to
+	// restore. Instead, best-effort delete the version dir this run tried to create.
+	if (context.config.versioning) {
+		return cleanupOrphanedVersion(context).map(() => ({ restoredSourceIds: [] }));
+	}
 
 	if (!context.config.backupAndRestore) {
 		return okAsync({ restoredSourceIds: [] });

--- a/packages/content/src/fetching/fetch-stages.ts
+++ b/packages/content/src/fetching/fetch-stages.ts
@@ -16,6 +16,7 @@ import {
 } from "../content-transform.js";
 import type { Manifest } from "../manifest.js";
 import * as ManifestUtils from "../manifest.js";
+import { type SweepResult, sweepVersions } from "../retention-sweep.js";
 import type { ContentSource } from "../source.js";
 import { FetchLogger } from "../utils/fetch-logger.js";
 import * as FileUtils from "../utils/file-utils.js";
@@ -534,6 +535,25 @@ export function finalizingStage(context: FetchStageContext): ResultAsync<void, C
 				sources: context.sources?.map((s) => s.id) || [],
 			});
 		});
+}
+
+/**
+ * Stage 6 (Versioned only): keep-N retention sweep of `versions/`, run once per successful
+ * versioned fetch. A no-op (resolves `undefined`) with versioning off. Never fails the fetch:
+ * a version dir that can't be fully removed is left in place and reported as pending-delete,
+ * to be retried on the next sweep.
+ */
+export function sweepStage(
+	context: FetchStageContext,
+): ResultAsync<SweepResult | undefined, never> {
+	context.logger.debug("Beginning phase: sweeping-versions");
+
+	if (!context.config.versioning) {
+		return okAsync(undefined);
+	}
+
+	const downloadPath = context.paths.getPublishedDownloadPath();
+	return sweepVersions(downloadPath, context.config.versioning, context.logger);
 }
 
 /**

--- a/packages/content/src/fetching/fetch-stages.ts
+++ b/packages/content/src/fetching/fetch-stages.ts
@@ -21,19 +21,99 @@ import { FetchLogger } from "../utils/fetch-logger.js";
 import * as FileUtils from "../utils/file-utils.js";
 import type { FetchStageContext } from "./fetch-context.js";
 
+/**
+ * Reads `manifest.json` once per `clearOldDataStage` call under versioning, warning a single
+ * time if it's missing or unreadable so per-source seeding can degrade to empty without
+ * repeating the warning for every source.
+ */
+function readActiveVersionManifest(
+	context: FetchStageContext,
+): ResultAsync<Manifest | undefined, never> {
+	const publishedRoot = context.paths.getPublishedDownloadPath();
+
+	return ResultAsync.fromSafePromise(ManifestUtils.readManifest(publishedRoot)).map((result) => {
+		if (result.status === "ok") {
+			return result.manifest;
+		}
+
+		if (result.status === "missing") {
+			context.logger.warn(
+				`No manifest found at ${publishedRoot}; seeding staged directories empty for this fetch.`,
+			);
+		} else {
+			context.logger.warn(
+				`Failed to read manifest at ${publishedRoot}: ${result.error.message}; seeding staged directories empty for this fetch.`,
+			);
+		}
+
+		return undefined;
+	});
+}
+
+/**
+ * Resolves the directory `clearOldDataStage` should seed keep-matching files from. Off
+ * versioning, that's today's published source path. Under versioning, it's the active
+ * version's directory for this source, resolved via the manifest's `sources[].path` — never
+ * "newest dir on disk" — so a never-promoted orphan can't be used as a seed.
+ */
+function resolveSeedPath(
+	context: FetchStageContext,
+	sourceId: string,
+	activeManifest: Manifest | undefined,
+): ResultAsync<string | undefined, FileUtils.FileUtilsError> {
+	if (!context.config.versioning) {
+		return okAsync(context.paths.getPublishedDownloadPath(sourceId));
+	}
+
+	if (!activeManifest) {
+		return okAsync(undefined);
+	}
+
+	const manifestSource = activeManifest.sources.find((source) => source.sourceId === sourceId);
+	if (!manifestSource) {
+		context.logger.warn(
+			`Active version ${activeManifest.versionId} has no entry for source ${sourceId}; seeding staged directory empty.`,
+		);
+		return okAsync(undefined);
+	}
+
+	const versionSourcePath = path.join(
+		context.paths.getPublishedDownloadPath(),
+		activeManifest.versionPath,
+		manifestSource.path,
+	);
+
+	return FileUtils.pathExists(versionSourcePath).andThen((exists) => {
+		if (!exists) {
+			context.logger.warn(
+				`Active version directory not found at ${versionSourcePath}; seeding staged directory for ${sourceId} empty.`,
+			);
+			return okAsync(undefined);
+		}
+		return okAsync(versionSourcePath);
+	});
+}
+
 function prepareStagedSourceDirectory(
 	context: FetchStageContext,
 	sourceId: string,
+	activeManifest: Manifest | undefined,
 ): ResultAsync<void, ContentError> {
 	const stagedPath = context.paths.getStagedDownloadPath(sourceId);
-	const publishedPath = context.paths.getPublishedDownloadPath(sourceId);
 
-	return FileUtils.clearDir(stagedPath, {
-		ignoreKeep: true,
-		removeIfEmpty: true,
-	})
-		.andThen(() => FileUtils.ensureDir(stagedPath))
-		.andThen(() => FileUtils.copyMatchingFiles(publishedPath, stagedPath, context.config.keep))
+	return resolveSeedPath(context, sourceId, activeManifest)
+		.andThen((seedPath) =>
+			FileUtils.clearDir(stagedPath, {
+				ignoreKeep: true,
+				removeIfEmpty: true,
+			})
+				.andThen(() => FileUtils.ensureDir(stagedPath))
+				.andThen(() =>
+					seedPath
+						? FileUtils.copyMatchingFiles(seedPath, stagedPath, context.config.keep)
+						: okAsync(undefined),
+				),
+		)
 		.mapErr(
 			(error) =>
 				new ContentError(`Failed to prepare staged directory for ${sourceId}`, { cause: error }),
@@ -255,9 +335,15 @@ export function clearOldDataStage(context: FetchStageContext): ResultAsync<void,
 		return errAsync(new ContentError("Sources not initialized"));
 	}
 
-	return ResultAsync.combine(
-		context.sources.map((source) => prepareStagedSourceDirectory(context, source.id)),
-	).map(() => undefined);
+	const activeManifest = context.config.versioning
+		? readActiveVersionManifest(context)
+		: okAsync(undefined);
+
+	return activeManifest.andThen((manifest) =>
+		ResultAsync.combine(
+			context.sources.map((source) => prepareStagedSourceDirectory(context, source.id, manifest)),
+		).map(() => undefined),
+	);
 }
 
 /**

--- a/packages/content/src/launchpad-content.ts
+++ b/packages/content/src/launchpad-content.ts
@@ -20,6 +20,7 @@ import {
 	fetchSourcesStage,
 	finalizingStage,
 	runTransformsStage,
+	sweepStage,
 } from "./fetching/fetch-stages.js";
 import type { ContentSource } from "./source.js";
 import { DataStore } from "./utils/data-store.js";
@@ -115,6 +116,13 @@ function fetch(
 			return finalizingStage(context);
 		})
 		.andThen(() => {
+			ctx.stateManager.setPhase({ phase: "sweeping-versions" });
+			return sweepStage(context);
+		})
+		.andThen((sweepResult) => {
+			if (sweepResult) {
+				ctx.stateManager.recordSweep(sweepResult);
+			}
 			for (const source of context.sources) {
 				ctx.stateManager.markSourceSuccess(source.id);
 			}

--- a/packages/content/src/retention-sweep.ts
+++ b/packages/content/src/retention-sweep.ts
@@ -1,0 +1,113 @@
+import path from "node:path";
+import type { Logger } from "@bluecadet/launchpad-utils/logger";
+import { okAsync, ResultAsync } from "neverthrow";
+import { type AckLease, readAckLeases } from "./acks.js";
+import * as ManifestUtils from "./manifest.js";
+import * as FileUtils from "./utils/file-utils.js";
+
+/** Directory under `downloadPath` holding one dir per minted version. */
+export const VERSIONS_DIRNAME = "versions";
+
+const REMOVE_MAX_RETRIES = 3;
+const REMOVE_RETRY_DELAY_MS = 100;
+
+export type SweepResult = {
+	retainedVersionIds: string[];
+	deletedVersionIds: string[];
+	pendingDeleteVersionIds: string[];
+	acks: AckLease[];
+};
+
+export function getVersionsDirPath(downloadPath: string): string {
+	return path.join(downloadPath, VERSIONS_DIRNAME);
+}
+
+function listVersionDirs(versionsDir: string): ResultAsync<string[], never> {
+	return FileUtils.listDir(versionsDir)
+		.map((entries) => entries.filter((entry) => FileUtils.isDir(path.join(versionsDir, entry))))
+		.orElse(() => okAsync<string[]>([]));
+}
+
+function readActiveVersionId(downloadPath: string): ResultAsync<string | undefined, never> {
+	return ResultAsync.fromSafePromise(ManifestUtils.readManifest(downloadPath)).map((result) =>
+		result.status === "ok" ? result.manifest.versionId : undefined,
+	);
+}
+
+/**
+ * Runs the keep-N retention sweep for versioned output. The retention set is the `keep`
+ * newest version dirs by name (lexical sort equals chronological order, since version ids
+ * are UTC timestamps) union the manifest's active version union any versionId named by a
+ * fresh ack lease. Everything else under `versions/` is deleted.
+ *
+ * Deletion is best-effort and idempotent: a dir that fails to fully delete (e.g. a locked
+ * file on Windows) is left in place and reported as pending-delete. The retention set is
+ * re-derived from scratch on every call, so a pending-delete dir is simply reconsidered next
+ * sweep -- no separate orphan tracking is needed, crash debris ages out under the same rule.
+ */
+export function sweepVersions(
+	downloadPath: string,
+	retention: { keep: number; ackTimeout: number },
+	logger: Pick<Logger, "warn">,
+	now: Date = new Date(),
+): ResultAsync<SweepResult, never> {
+	const versionsDir = getVersionsDirPath(downloadPath);
+
+	return readAckLeases(downloadPath, retention.ackTimeout, logger, now).andThen((acks) =>
+		FileUtils.pathExists(versionsDir).andThen((versionsDirExists) => {
+			if (!versionsDirExists) {
+				return okAsync<SweepResult>({
+					retainedVersionIds: [],
+					deletedVersionIds: [],
+					pendingDeleteVersionIds: [],
+					acks,
+				});
+			}
+
+			return listVersionDirs(versionsDir).andThen((versionIds) =>
+				readActiveVersionId(downloadPath).andThen((activeVersionId) => {
+					const sortedIds = [...versionIds].sort();
+					const newestKept = retention.keep > 0 ? sortedIds.slice(-retention.keep) : [];
+					const retentionSet = new Set(newestKept);
+
+					if (activeVersionId) {
+						retentionSet.add(activeVersionId);
+					}
+					for (const ack of acks) {
+						if (ack.fresh) {
+							retentionSet.add(ack.versionId);
+						}
+					}
+
+					const retainedVersionIds = sortedIds.filter((versionId) => retentionSet.has(versionId));
+					const candidateVersionIds = sortedIds.filter((versionId) => !retentionSet.has(versionId));
+
+					return ResultAsync.combine(
+						candidateVersionIds.map((versionId) =>
+							FileUtils.remove(path.join(versionsDir, versionId), {
+								maxRetries: REMOVE_MAX_RETRIES,
+								retryDelay: REMOVE_RETRY_DELAY_MS,
+							})
+								.map(() => ({ versionId, deleted: true as const }))
+								.orElse((error) => {
+									logger.warn(
+										`Failed to remove version directory ${versionId} during retention sweep, will retry next sweep: ${error.message}`,
+									);
+									return okAsync({ versionId, deleted: false as const });
+								}),
+						),
+					).map((outcomes) => ({
+						retainedVersionIds,
+						deletedVersionIds: outcomes
+							.filter((outcome) => outcome.deleted)
+							.map((outcome) => outcome.versionId),
+						pendingDeleteVersionIds: outcomes
+							.filter((outcome) => !outcome.deleted)
+							.map((outcome) => outcome.versionId),
+						acks,
+					}));
+				}),
+			);
+		}),
+	);
+}

--- a/packages/content/src/utils/__tests__/file-utils.test.ts
+++ b/packages/content/src/utils/__tests__/file-utils.test.ts
@@ -159,6 +159,37 @@ describe("FileUtils", () => {
 			const result = await FileUtils.remove("/non-existing");
 			expect(result).toBeOk();
 		});
+
+		it("should default maxRetries/retryDelay to 0", async () => {
+			vol.mkdirSync("/test-dir");
+			const rmSpy = vi.spyOn(vol.promises, "rm");
+
+			await FileUtils.remove("/test-dir");
+
+			expect(rmSpy).toHaveBeenCalledWith("/test-dir", {
+				recursive: true,
+				force: true,
+				maxRetries: 0,
+				retryDelay: 0,
+			});
+			rmSpy.mockRestore();
+		});
+
+		it("should pass maxRetries/retryDelay through to fs.rm when provided", async () => {
+			vol.mkdirSync("/test-dir");
+			const rmSpy = vi.spyOn(vol.promises, "rm");
+
+			const result = await FileUtils.remove("/test-dir", { maxRetries: 3, retryDelay: 50 });
+
+			expect(result).toBeOk();
+			expect(rmSpy).toHaveBeenCalledWith("/test-dir", {
+				recursive: true,
+				force: true,
+				maxRetries: 3,
+				retryDelay: 50,
+			});
+			rmSpy.mockRestore();
+		});
 	});
 
 	describe("pathExists", () => {

--- a/packages/content/src/utils/file-utils.ts
+++ b/packages/content/src/utils/file-utils.ts
@@ -223,7 +223,7 @@ export function copyFile(src: string, dest: string): ResultAsync<void, FileUtils
  * Atomically replace a file or directory from `src` to `dest` when possible.
  * Falls back to copy + remove when rename cannot be used across devices.
  */
-function move(
+export function move(
 	src: string,
 	dest: string,
 	options = { preserveTimestamps: true },

--- a/packages/content/src/utils/file-utils.ts
+++ b/packages/content/src/utils/file-utils.ts
@@ -134,10 +134,20 @@ export function ensureDir(dirPath: string): ResultAsync<void, FileUtilsError> {
 
 /**
  * Removes a file or directory. The directory can have contents. If the path does not exist, silently does nothing.
+ * `maxRetries`/`retryDelay` default to 0 (no retry), matching `fs.rm`'s own defaults; pass them
+ * explicitly to retry transient locks (e.g. Windows sharing violations) on a multi-pass sweep.
  */
-export function remove(dir: string): ResultAsync<void, FileUtilsError> {
+export function remove(
+	dir: string,
+	options: { maxRetries?: number; retryDelay?: number } = {},
+): ResultAsync<void, FileUtilsError> {
 	return ResultAsync.fromPromise(
-		fs.promises.rm(dir, { recursive: true, force: true }),
+		fs.promises.rm(dir, {
+			recursive: true,
+			force: true,
+			maxRetries: options.maxRetries ?? 0,
+			retryDelay: options.retryDelay ?? 0,
+		}),
 		(e) => new FileUtilsError(`Failed to remove ${dir}`, { cause: e }),
 	);
 }

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -42,6 +42,7 @@
   "homepage": "https://github.com/bluecadet/launchpad/packages/scheduler",
   "dependencies": {
     "@bluecadet/launchpad-utils": "~3.0.0",
+    "croner": "^10.0.1",
     "neverthrow": "^8.2.0",
     "zod": "^4.3.6"
   },

--- a/packages/scheduler/src/__tests__/jitter.test.ts
+++ b/packages/scheduler/src/__tests__/jitter.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { randomJitterMs, resolveJitterMs } from "../jitter.js";
+
+describe("resolveJitterMs", () => {
+	it("resolves false to zero", () => {
+		expect(resolveJitterMs(false, 300_000)).toBe(0);
+	});
+
+	it("resolves true to 10% of the base", () => {
+		expect(resolveJitterMs(true, 300_000)).toBe(30_000);
+	});
+
+	it("resolves an explicit duration to itself, independent of the base", () => {
+		expect(resolveJitterMs(45_000, 300_000)).toBe(45_000);
+	});
+});
+
+describe("randomJitterMs", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns zero for a non-positive max", () => {
+		expect(randomJitterMs(0)).toBe(0);
+		expect(randomJitterMs(-10)).toBe(0);
+	});
+
+	it("stays within [0, max)", () => {
+		vi.spyOn(Math, "random").mockReturnValue(0.9999);
+		expect(randomJitterMs(1000)).toBeCloseTo(999.9, 0);
+
+		vi.spyOn(Math, "random").mockReturnValue(0);
+		expect(randomJitterMs(1000)).toBe(0);
+	});
+
+	it("rerolls a fresh value on every call", () => {
+		const values = [0.1, 0.5, 0.9];
+		const randomSpy = vi.spyOn(Math, "random");
+		for (const value of values) randomSpy.mockReturnValueOnce(value);
+
+		const results = values.map(() => randomJitterMs(1000));
+
+		expect(results).toEqual(values.map((v) => v * 1000));
+	});
+});

--- a/packages/scheduler/src/__tests__/launchpad-scheduler.test.ts
+++ b/packages/scheduler/src/__tests__/launchpad-scheduler.test.ts
@@ -1,5 +1,5 @@
 import { createMockPluginCtx } from "@bluecadet/launchpad-testing/test-utils.ts";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { scheduler } from "../launchpad-scheduler.js";
 
 describe("scheduler plugin", () => {
@@ -22,5 +22,49 @@ describe("scheduler plugin", () => {
 		const result = await plugin.setup(createMockPluginCtx());
 
 		expect(result).toBeErr();
+	});
+
+	describe("scheduling behavior", () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("dispatches zero commands when no jobs are configured", async () => {
+			const ctx = createMockPluginCtx();
+			const plugin = scheduler({});
+			await plugin.setup(ctx);
+
+			await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+
+			expect(ctx.dispatchCommand).not.toHaveBeenCalled();
+		});
+
+		it("dispatches the configured command once its interval elapses", async () => {
+			const ctx = createMockPluginCtx();
+			const plugin = scheduler({ "content.fetch": { interval: "5m", jitter: false } });
+			await plugin.setup(ctx);
+
+			await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+			expect(ctx.dispatchCommand).toHaveBeenCalledExactlyOnceWith({ type: "content.fetch" });
+		});
+
+		it("cancels all timers on disconnect", async () => {
+			const ctx = createMockPluginCtx();
+			const plugin = scheduler({ "content.fetch": { interval: "5m", jitter: false } });
+			const result = await plugin.setup(ctx);
+			if (result.isErr() || !result.value.disconnect) {
+				throw new Error("Expected setup to return a disconnectable plugin instance");
+			}
+
+			await result.value.disconnect({ type: "manual" });
+			await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+
+			expect(ctx.dispatchCommand).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/scheduler/src/__tests__/overlap.test.ts
+++ b/packages/scheduler/src/__tests__/overlap.test.ts
@@ -1,0 +1,24 @@
+import { CommandInProgressError } from "@bluecadet/launchpad-utils/command-guard";
+import { describe, expect, it } from "vitest";
+import { isOverlapSkipError } from "../overlap.js";
+
+describe("isOverlapSkipError", () => {
+	it("detects an unwrapped CommandInProgressError", () => {
+		expect(isOverlapSkipError(new CommandInProgressError())).toBe(true);
+	});
+
+	it("detects a CommandInProgressError wrapped as `cause` (the dispatcher's shape)", () => {
+		const wrapped = new Error("Plugin command execution failed", {
+			cause: new CommandInProgressError(),
+		});
+		expect(isOverlapSkipError(wrapped)).toBe(true);
+	});
+
+	it("returns false for an unrelated error", () => {
+		expect(isOverlapSkipError(new Error("boom"))).toBe(false);
+	});
+
+	it("returns false for an error wrapping an unrelated cause", () => {
+		expect(isOverlapSkipError(new Error("boom", { cause: new Error("nested") }))).toBe(false);
+	});
+});

--- a/packages/scheduler/src/__tests__/scheduled-job.test.ts
+++ b/packages/scheduler/src/__tests__/scheduled-job.test.ts
@@ -1,0 +1,265 @@
+import { createMockLogger } from "@bluecadet/launchpad-testing/test-utils.ts";
+import { CommandInProgressError } from "@bluecadet/launchpad-utils/command-guard";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ScheduledJob } from "../scheduled-job.js";
+import { resolveSchedulerConfig, type ScheduleSpec } from "../scheduler-config.js";
+
+function getSpec(overrides: Record<string, unknown> = {}) {
+	const resolved = resolveSchedulerConfig({
+		"content.fetch": { interval: "60s", ...overrides } as ScheduleSpec,
+	});
+	const spec = resolved["content.fetch"];
+	if (!spec) throw new Error("Expected resolved spec for content.fetch");
+	return spec;
+}
+
+describe("ScheduledJob", () => {
+	let logger: ReturnType<typeof createMockLogger>;
+
+	beforeEach(() => {
+		// Cron wall-clock semantics are intentionally local-timezone (kiosk business hours);
+		// pin to UTC here so the cron-job assertions below are portable across CI machines.
+		process.env.TZ = "UTC";
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+		logger = createMockLogger();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	describe("interval jobs", () => {
+		it("anchors the next tick to completion, not to the previous fire time", async () => {
+			const dispatch = vi
+				.fn()
+				.mockImplementation(() =>
+					ResultAsync.fromPromise(
+						new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 10_000)),
+						(e) => e as Error,
+					),
+				);
+			const job = new ScheduledJob("content.fetch", getSpec({ interval: "60s", jitter: false }), {
+				logger,
+				dispatch,
+			});
+
+			job.start();
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+
+			// Dispatch is still in flight (takes 10s); no next tick should be scheduled yet.
+			await vi.advanceTimersByTimeAsync(59_999);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+
+			// Dispatch completes at t=70s; next tick anchors 60s from there (t=130s), not from
+			// the fire time (which would have been t=120s).
+			await vi.advanceTimersByTimeAsync(10_000); // t=129_999
+			expect(dispatch).toHaveBeenCalledTimes(1);
+			await vi.advanceTimersByTimeAsync(1); // t=130_000
+			expect(dispatch).toHaveBeenCalledTimes(2);
+		});
+
+		it("treats a real command failure like a success for scheduling purposes", async () => {
+			const dispatch = vi.fn().mockReturnValue(errAsync(new Error("boom")));
+			const job = new ScheduledJob("content.fetch", getSpec({ interval: "60s", jitter: false }), {
+				logger,
+				dispatch,
+			});
+
+			job.start();
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+			expect(logger.error).toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(dispatch).toHaveBeenCalledTimes(2);
+		});
+
+		it("treats CommandInProgressError as a skip: no failure log, counter increments, next tick on time", async () => {
+			const overlapError = new Error("Plugin command execution failed", {
+				cause: new CommandInProgressError(),
+			});
+			const dispatch = vi.fn().mockReturnValue(errAsync(overlapError));
+			const job = new ScheduledJob("content.fetch", getSpec({ interval: "60s", jitter: false }), {
+				logger,
+				dispatch,
+			});
+
+			job.start();
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+			expect(job.skippedOverlapCount).toBe(1);
+			expect(logger.error).not.toHaveBeenCalled();
+			expect(logger.info).toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(dispatch).toHaveBeenCalledTimes(2);
+			expect(job.skippedOverlapCount).toBe(2);
+		});
+	});
+
+	describe("cron jobs", () => {
+		it("fires at the wall-clock occurrence and schedules the next one up front", async () => {
+			const dispatch = vi.fn().mockReturnValue(okAsync(undefined));
+			const job = new ScheduledJob(
+				"content.sync",
+				getSpec({ interval: undefined, cron: "0 3 * * *", jitter: false }),
+				{
+					logger,
+					dispatch,
+				},
+			);
+
+			job.start();
+			await vi.advanceTimersByTimeAsync(3 * 60 * 60 * 1000 - 1);
+			expect(dispatch).not.toHaveBeenCalled();
+			await vi.advanceTimersByTimeAsync(1);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+
+			await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000 - 1);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+			await vi.advanceTimersByTimeAsync(1);
+			expect(dispatch).toHaveBeenCalledTimes(2);
+		});
+
+		it("skips an overlap without disrupting the wall-clock cadence", async () => {
+			const overlapError = new Error("Plugin command execution failed", {
+				cause: new CommandInProgressError(),
+			});
+			const dispatch = vi.fn().mockReturnValue(errAsync(overlapError));
+			const job = new ScheduledJob(
+				"content.sync",
+				getSpec({ interval: undefined, cron: "* * * * *", jitter: false }),
+				{
+					logger,
+					dispatch,
+				},
+			);
+
+			job.start();
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+			expect(job.skippedOverlapCount).toBe(1);
+			expect(logger.error).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(dispatch).toHaveBeenCalledTimes(2);
+			expect(job.skippedOverlapCount).toBe(2);
+		});
+	});
+
+	describe("jitter", () => {
+		it("rerolls a fresh jitter contribution on every scheduled tick", async () => {
+			const dispatch = vi.fn().mockReturnValue(okAsync(undefined));
+			const randomSpy = vi.spyOn(Math, "random");
+			randomSpy.mockReturnValueOnce(0).mockReturnValueOnce(0.5);
+
+			const job = new ScheduledJob("content.fetch", getSpec({ interval: "100s", jitter: true }), {
+				logger,
+				dispatch,
+			});
+			const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+			job.start();
+			// random()=0 => 100_000 + 0
+			expect(setTimeoutSpy.mock.calls[0]?.[1]).toBe(100_000);
+
+			await vi.advanceTimersByTimeAsync(100_000);
+			// random()=0.5 => 100_000 + (100_000 * 0.1 * 0.5) = 105_000
+			const secondDelay = setTimeoutSpy.mock.calls.at(-1)?.[1];
+			expect(secondDelay).toBe(105_000);
+			expect(secondDelay).not.toBe(setTimeoutSpy.mock.calls[0]?.[1]);
+		});
+	});
+
+	describe("runOnStart", () => {
+		it("waits one full interval before the first dispatch when false", async () => {
+			const dispatch = vi.fn().mockReturnValue(okAsync(undefined));
+			const job = new ScheduledJob(
+				"content.fetch",
+				getSpec({ interval: "60s", jitter: false, runOnStart: false }),
+				{ logger, dispatch },
+			);
+
+			job.start();
+			expect(dispatch).not.toHaveBeenCalled();
+			await vi.advanceTimersByTimeAsync(59_999);
+			expect(dispatch).not.toHaveBeenCalled();
+			await vi.advanceTimersByTimeAsync(1);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+		});
+
+		it("dispatches immediately at start when true, then resumes the normal cadence", async () => {
+			const dispatch = vi.fn().mockReturnValue(okAsync(undefined));
+			const job = new ScheduledJob(
+				"content.fetch",
+				getSpec({ interval: "60s", jitter: false, runOnStart: true }),
+				{ logger, dispatch },
+			);
+
+			job.start();
+			await vi.advanceTimersByTimeAsync(0);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+
+			await vi.advanceTimersByTimeAsync(59_999);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+			await vi.advanceTimersByTimeAsync(1);
+			expect(dispatch).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("enabled: false", () => {
+		it("never schedules or dispatches", async () => {
+			const dispatch = vi.fn().mockReturnValue(okAsync(undefined));
+			const job = new ScheduledJob("content.fetch", getSpec({ interval: "60s", enabled: false }), {
+				logger,
+				dispatch,
+			});
+
+			job.start();
+			await vi.advanceTimersByTimeAsync(10 * 60_000);
+			expect(dispatch).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("stop", () => {
+		it("cancels the pending timer so no further dispatches occur", async () => {
+			const dispatch = vi.fn().mockReturnValue(okAsync(undefined));
+			const job = new ScheduledJob("content.fetch", getSpec({ interval: "60s", jitter: false }), {
+				logger,
+				dispatch,
+			});
+
+			job.start();
+			job.stop();
+			await vi.advanceTimersByTimeAsync(10 * 60_000);
+			expect(dispatch).not.toHaveBeenCalled();
+		});
+
+		it("lets an in-flight dispatch finish but does not schedule another tick", async () => {
+			const dispatch = vi
+				.fn()
+				.mockImplementation(() =>
+					ResultAsync.fromPromise(
+						new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 10_000)),
+						(e) => e as Error,
+					),
+				);
+			const job = new ScheduledJob("content.fetch", getSpec({ interval: "60s", jitter: false }), {
+				logger,
+				dispatch,
+			});
+
+			job.start();
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+
+			job.stop();
+			await vi.advanceTimersByTimeAsync(10_000 + 60_000);
+			expect(dispatch).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/scheduler/src/__tests__/timing.test.ts
+++ b/packages/scheduler/src/__tests__/timing.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCronDelay, createDelayFn, createIntervalDelay } from "../timing.js";
+
+describe("createIntervalDelay", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("ignores `from` and always returns the configured interval when jitter is off", () => {
+		const delay = createIntervalDelay(300_000, false);
+		expect(delay(new Date("2026-01-01T00:00:00Z"))).toBe(300_000);
+		expect(delay(new Date("2030-06-15T12:00:00Z"))).toBe(300_000);
+	});
+
+	it("adds a jitter contribution bounded by the resolved jitter amount", () => {
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		const delay = createIntervalDelay(300_000, true);
+		// true => 10% of 300_000 = 30_000; at random()=0.5 => +15_000
+		expect(delay(new Date())).toBe(315_000);
+	});
+});
+
+describe("createCronDelay", () => {
+	beforeEach(() => {
+		// Cron wall-clock semantics are intentionally local-timezone (kiosk business hours);
+		// pin to UTC here so the expected offsets below are portable across CI machines.
+		process.env.TZ = "UTC";
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("computes the delay until the next wall-clock occurrence", () => {
+		const delay = createCronDelay("0 3 * * *", false);
+		const from = new Date("2026-01-01T00:00:00Z");
+		expect(delay(from)).toBe(3 * 60 * 60 * 1000);
+	});
+
+	it("recomputes from a later reference point (no wall-clock drift)", () => {
+		const delay = createCronDelay("0 3 * * *", false);
+		const from = new Date("2026-01-01T03:00:00Z");
+		// nextRun is exclusive: firing exactly at 3am rolls to the next day's 3am.
+		expect(delay(from)).toBe(24 * 60 * 60 * 1000);
+	});
+
+	it("adds jitter as a percentage of the computed gap", () => {
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		const delay = createCronDelay("0 3 * * *", true);
+		const from = new Date("2026-01-01T00:00:00Z");
+		const base = 3 * 60 * 60 * 1000;
+		expect(delay(from)).toBe(base + base * 0.1 * 0.5);
+	});
+});
+
+describe("createDelayFn", () => {
+	it("picks the cron delay when `cron` is set", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+		const delay = createDelayFn({
+			cron: "0 3 * * *",
+			jitter: false,
+			retry: { forever: true, backoff: { initial: 15_000, max: 300_000, factor: 2 } },
+			command: { type: "content.sync" },
+			runOnStart: false,
+			enabled: true,
+		});
+		expect(delay(new Date("2026-01-01T00:00:00Z"))).toBe(3 * 60 * 60 * 1000);
+	});
+
+	it("picks the interval delay when `interval` is set", () => {
+		const delay = createDelayFn({
+			interval: 60_000,
+			jitter: false,
+			retry: { forever: true, backoff: { initial: 15_000, max: 300_000, factor: 2 } },
+			command: { type: "content.fetch" },
+			runOnStart: false,
+			enabled: true,
+		});
+		expect(delay(new Date())).toBe(60_000);
+	});
+});

--- a/packages/scheduler/src/cron.ts
+++ b/packages/scheduler/src/cron.ts
@@ -1,0 +1,11 @@
+import { Cron } from "croner";
+
+/**
+ * Builds a function that resolves the next wall-clock fire `Date` after a given point in
+ * time, for a validated 5-field cron expression. `paused: true` means croner is only used
+ * as an expression evaluator here — it never schedules or runs anything itself.
+ */
+export function createCronNextRun(cronExpression: string): (from: Date) => Date | null {
+	const job = new Cron(cronExpression, { paused: true });
+	return (from: Date) => job.nextRun(from);
+}

--- a/packages/scheduler/src/jitter.ts
+++ b/packages/scheduler/src/jitter.ts
@@ -1,0 +1,17 @@
+const DEFAULT_JITTER_RATIO = 0.1;
+
+/**
+ * Resolves a job's jitter config to a maximum jitter duration in ms.
+ * `true` defaults to ~10% of the base delay it's applied against.
+ */
+export function resolveJitterMs(jitter: boolean | number, baseMs: number): number {
+	if (jitter === false) return 0;
+	if (jitter === true) return baseMs * DEFAULT_JITTER_RATIO;
+	return jitter;
+}
+
+/** Rolls a random jitter contribution in [0, maxJitterMs). */
+export function randomJitterMs(maxJitterMs: number): number {
+	if (maxJitterMs <= 0) return 0;
+	return Math.random() * maxJitterMs;
+}

--- a/packages/scheduler/src/launchpad-scheduler.ts
+++ b/packages/scheduler/src/launchpad-scheduler.ts
@@ -1,7 +1,12 @@
-import { definePlugin, type PluginContext } from "@bluecadet/launchpad-utils/plugin-interfaces";
+import {
+	type DisconnectReason,
+	definePlugin,
+	type PluginContext,
+} from "@bluecadet/launchpad-utils/plugin-interfaces";
 import { errAsync, okAsync } from "neverthrow";
 import { SchedulerError } from "./errors.js";
 import { type SchedulerConfig, schedulerConfigSchema } from "./scheduler-config.js";
+import { SchedulerEngine } from "./scheduler-engine.js";
 
 /**
  * Creates a Launchpad Scheduler plugin factory.
@@ -10,7 +15,7 @@ import { type SchedulerConfig, schedulerConfigSchema } from "./scheduler-config.
 export function scheduler(config: SchedulerConfig) {
 	return definePlugin({
 		name: "scheduler",
-		setup(_ctx: PluginContext) {
+		setup(ctx: PluginContext) {
 			const configResult = schedulerConfigSchema.safeParse(config);
 			if (!configResult.success) {
 				return errAsync(
@@ -18,7 +23,18 @@ export function scheduler(config: SchedulerConfig) {
 				);
 			}
 
-			return okAsync({});
+			const engine = new SchedulerEngine(configResult.data, {
+				logger: ctx.logger,
+				dispatch: ctx.dispatchCommand,
+			});
+			engine.start();
+
+			return okAsync({
+				disconnect(_reason: DisconnectReason) {
+					engine.stop();
+					return okAsync(undefined);
+				},
+			});
 		},
 	});
 }

--- a/packages/scheduler/src/overlap.ts
+++ b/packages/scheduler/src/overlap.ts
@@ -1,0 +1,11 @@
+import { CommandInProgressError } from "@bluecadet/launchpad-utils/command-guard";
+
+/**
+ * `ctx.dispatchCommand` wraps a rejected `SingleCommandGuard` in a `CommandExecutionError`
+ * whose `cause` is the original `CommandInProgressError`. Checking both the error itself and
+ * its cause keeps this independent of the controller's wrapping so it also works if a plugin
+ * ever forwards the guard error unwrapped.
+ */
+export function isOverlapSkipError(error: Error): boolean {
+	return error instanceof CommandInProgressError || error.cause instanceof CommandInProgressError;
+}

--- a/packages/scheduler/src/scheduled-job.ts
+++ b/packages/scheduler/src/scheduled-job.ts
@@ -1,0 +1,105 @@
+import type { Logger } from "@bluecadet/launchpad-utils/logger";
+import type { BaseCommand, CommandId } from "@bluecadet/launchpad-utils/plugin-interfaces";
+import type { ResultAsync } from "neverthrow";
+import { isOverlapSkipError } from "./overlap.js";
+import type { ResolvedScheduleSpec } from "./scheduler-config.js";
+import { createDelayFn, type DelayFn } from "./timing.js";
+
+export type DispatchFn = (command: BaseCommand) => ResultAsync<unknown, Error>;
+
+export type ScheduledJobDeps = {
+	logger: Logger;
+	dispatch: DispatchFn;
+};
+
+/**
+ * Runs one job's chained-`setTimeout` lifecycle.
+ *
+ * Interval jobs anchor their next fire to the *completion* of the previous run, so
+ * self-overlap is structurally impossible. Cron jobs are wall-clock anchored: the next
+ * occurrence is scheduled the moment a tick fires, without waiting on that tick's dispatch —
+ * a fire landing while the previous run is still in flight is left to the downstream
+ * command's own guard, and rejection is treated as a skip rather than a failure.
+ */
+export class ScheduledJob {
+	private readonly _computeDelayMs: DelayFn;
+	private readonly _isWallClockAnchored: boolean;
+	private _timer: NodeJS.Timeout | null = null;
+	private _stopped = true;
+	private _skippedOverlapCount = 0;
+
+	constructor(
+		private readonly _commandId: CommandId,
+		private readonly _spec: ResolvedScheduleSpec,
+		private readonly _deps: ScheduledJobDeps,
+	) {
+		this._isWallClockAnchored = this._spec.cron !== undefined;
+		this._computeDelayMs = createDelayFn(this._spec);
+	}
+
+	/** Number of dispatches skipped because the command was already in progress. */
+	get skippedOverlapCount(): number {
+		return this._skippedOverlapCount;
+	}
+
+	/** Schedules the job from `now`. No-op for `enabled: false` jobs. */
+	start(): void {
+		if (!this._spec.enabled) return;
+		this._stopped = false;
+		if (this._spec.runOnStart) {
+			this.onTick(new Date());
+		} else {
+			this.scheduleNext(new Date());
+		}
+	}
+
+	/** Cancels any pending timer. In-flight dispatches are left to finish on their own. */
+	stop(): void {
+		this._stopped = true;
+		if (this._timer) {
+			clearTimeout(this._timer);
+			this._timer = null;
+		}
+	}
+
+	private scheduleNext(from: Date): void {
+		if (this._stopped) return;
+		const delayMs = this._computeDelayMs(from);
+		this._timer = setTimeout(() => {
+			this._timer = null;
+			this.onTick(new Date());
+		}, delayMs);
+	}
+
+	private onTick(referenceTime: Date): void {
+		if (this._stopped) return;
+
+		if (this._isWallClockAnchored) {
+			// Cron never queues: the next occurrence is scheduled up front, alongside dispatch.
+			this.scheduleNext(referenceTime);
+			void this.dispatchAndObserve();
+			return;
+		}
+
+		void this.dispatchAndObserve().then((completedAt) => {
+			this.scheduleNext(completedAt);
+		});
+	}
+
+	private dispatchAndObserve(): Promise<Date> {
+		return this._deps
+			.dispatch(this._spec.command)
+			.match(
+				() => undefined,
+				(error) => {
+					if (isOverlapSkipError(error)) {
+						this._skippedOverlapCount += 1;
+						this._deps.logger.info(`Skipped ${this._commandId}: command already in progress`);
+					} else {
+						this._deps.logger.error(`${this._commandId} failed`, error);
+					}
+				},
+			)
+			.then(() => new Date());
+	}
+}

--- a/packages/scheduler/src/scheduler-engine.ts
+++ b/packages/scheduler/src/scheduler-engine.ts
@@ -1,0 +1,30 @@
+import type { CommandId } from "@bluecadet/launchpad-utils/plugin-interfaces";
+import { ScheduledJob, type ScheduledJobDeps } from "./scheduled-job.js";
+import type { ResolvedSchedulerConfig } from "./scheduler-config.js";
+
+/** Owns the set of scheduled jobs built from a resolved scheduler config. */
+export class SchedulerEngine {
+	private readonly _jobs = new Map<CommandId, ScheduledJob>();
+
+	constructor(config: ResolvedSchedulerConfig, deps: ScheduledJobDeps) {
+		for (const [rawCommandId, spec] of Object.entries(config)) {
+			if (!spec) continue;
+			const commandId = rawCommandId as CommandId;
+			this._jobs.set(commandId, new ScheduledJob(commandId, spec, deps));
+		}
+	}
+
+	/** Starts every configured job from `now`. */
+	start(): void {
+		for (const job of this._jobs.values()) {
+			job.start();
+		}
+	}
+
+	/** Cancels every job's pending timer. */
+	stop(): void {
+		for (const job of this._jobs.values()) {
+			job.stop();
+		}
+	}
+}

--- a/packages/scheduler/src/timing.ts
+++ b/packages/scheduler/src/timing.ts
@@ -1,0 +1,37 @@
+import { createCronNextRun } from "./cron.js";
+import { randomJitterMs, resolveJitterMs } from "./jitter.js";
+import type { ResolvedScheduleSpec } from "./scheduler-config.js";
+
+/** Computes the delay in ms until a job's next fire, given the point in time to compute from. */
+export type DelayFn = (from: Date) => number;
+
+/**
+ * Interval delays never depend on wall-clock alignment: it's always the configured
+ * interval plus a freshly-rolled jitter contribution, regardless of `from`.
+ */
+export function createIntervalDelay(intervalMs: number, jitter: boolean | number): DelayFn {
+	return () => intervalMs + randomJitterMs(resolveJitterMs(jitter, intervalMs));
+}
+
+/**
+ * Cron delays are wall-clock anchored: the base delay is however long until the next
+ * matching occurrence after `from`, with jitter rolled as a percentage of that gap.
+ */
+export function createCronDelay(cronExpression: string, jitter: boolean | number): DelayFn {
+	const nextRun = createCronNextRun(cronExpression);
+	return (from: Date) => {
+		const next = nextRun(from);
+		const baseDelayMs = next ? Math.max(0, next.getTime() - from.getTime()) : 0;
+		return baseDelayMs + randomJitterMs(resolveJitterMs(jitter, baseDelayMs));
+	};
+}
+
+/** Builds the right delay function for a resolved schedule spec's `interval` XOR `cron`. */
+export function createDelayFn(spec: ResolvedScheduleSpec): DelayFn {
+	if (spec.cron !== undefined) {
+		return createCronDelay(spec.cron, spec.jitter);
+	}
+	// `scheduleObjectSchema`'s `.superRefine` guarantees exactly one of `interval`/`cron` is set,
+	// so `interval` is defined whenever `cron` isn't — TS can't express that XOR structurally.
+	return createIntervalDelay(spec.interval as number, spec.jitter);
+}


### PR DESCRIPTION
## Summary
- Keep-N retention sweep for versioned output, run at the end of each successful versioned fetch: retention set is the `keep` newest version dirs by name, union the manifest's active version, union any version named by a fresh ack lease.
- Ack lease reading (`acks/<consumerId>.json`, freshness by mtime vs `ackTimeout`); unparseable/unreadable leases are dropped with a warning.
- Deletion is best-effort and idempotent (`FileUtils.remove` now accepts `maxRetries`/`retryDelay`) — a locked dir is left in place and retried next sweep, surfaced as pending-delete.
- Sweep results tracked on `ContentState` (`retention` field, `sweeping-versions` phase) for a later status-rows ticket to surface.

Implements `.agents/issues/live-content-refresh-impl/09-retention-sweep.md`. The `content.ack` IPC command (#10) and status rows (#11) are separate tickets, deliberately not touched here.

## Test plan
- [x] `npx tsc --build` clean across the monorepo
- [x] Full `packages/content` vitest suite passes (33 files / 349 tests)
- [x] New unit tests: `acks.test.ts`, `retention-sweep.test.ts`, plus coverage added to `fetch-stages.test.ts` and `content-state.test.ts`
- [x] `/code-review` (Standards + Spec axes) run — no hard violations found