### PR TITLE
feat(content): add Strapi v5 support, default to v5

### DIFF
--- a/.changeset/strapi-five.md
+++ b/.changeset/strapi-five.md
@@ -1,0 +1,9 @@
+---
+"@bluecadet/launchpad-content": minor
+---
+
+Add Strapi v5 support to `strapiSource`, and make it the new default `version` ("5", up from "3"). v5 uses the same pagination and query params as v4, and its flattened entry shape (fields at the top level plus `documentId`) is passed through to saved JSON as-is.
+
+Breaking: projects that don't set `version` explicitly previously got v3 behavior and will now get v5. Set `version: "3"` or `version: "4"` explicitly to keep the previous behavior.
+
+Also fixes the login auth endpoint: it's now version-aware, posting to `{baseUrl}/auth/local` for v3 and `{baseUrl}/api/auth/local` for v4 and v5. Previously it always posted to `/auth/local`, which was incorrect for v4. Token-based auth is unaffected.

--- a/docs/src/reference/content/sources/strapi-source.md
+++ b/docs/src/reference/content/sources/strapi-source.md
@@ -1,6 +1,6 @@
 # Strapi Content Source
 
-The `strapiSource` content source is used to fetch data from Strapi CMS. It supports both Strapi v3 and v4, with automatic pagination and customizable query parameters.
+The `strapiSource` content source is used to fetch data from Strapi CMS. It supports Strapi v3, v4, and v5, with automatic pagination and customizable query parameters.
 
 ## Usage
 
@@ -15,7 +15,6 @@ export default defineConfig({
       sources: [
         strapiSource({
           id: 'myStrapiSource',
-          version: '4',
           baseUrl: 'http://localhost:1337',
           identifier: 'admin@example.com',
           password: 'your-password',
@@ -38,10 +37,10 @@ Specifies the unique identifier for this source. This will be used as the downlo
 
 ### `version`
 
-- **Type:** `"3" | "4"`
-- **Default:** `"3"`
+- **Type:** `"3" | "4" | "5"`
+- **Default:** `"5"`
 
-Specifies the Strapi version. Supports either version 3 or 4.
+Specifies the Strapi version. Supports version 3, 4, or 5. Strapi v5 flattens entry attributes to the top level of each entry (alongside a `documentId`), rather than nesting them under `attributes` as v4 does; this source passes v5 entries through as-is. If you're on an older Strapi instance, set this explicitly to `"3"` or `"4"`.
 
 ### `baseUrl`
 

--- a/packages/content/src/sources/__tests__/strapi-source.test.ts
+++ b/packages/content/src/sources/__tests__/strapi-source.test.ts
@@ -42,7 +42,7 @@ describe.runIf(majorNodeVersion >= 20)("strapiSource", () => {
 				identifier: "test@example.com",
 				password: "password",
 				// @ts-expect-error - testing invalid version
-				version: "5",
+				version: "6",
 				queries: ["test-content"],
 			}),
 		).rejects.toThrowErrorMatchingInlineSnapshot(`
@@ -51,12 +51,13 @@ describe.runIf(majorNodeVersion >= 20)("strapiSource", () => {
 			    "code": "invalid_value",
 			    "values": [
 			      "3",
-			      "4"
+			      "4",
+			      "5"
 			    ],
 			    "path": [
 			      "version"
 			    ],
-			    "message": "Invalid option: expected one of \\"3\\"|\\"4\\""
+			    "message": "Invalid option: expected one of \\"3\\"|\\"4\\"|\\"5\\""
 			  }
 			]]
 		`);
@@ -66,7 +67,7 @@ describe.runIf(majorNodeVersion >= 20)("strapiSource", () => {
 		it("should authenticate and fetch data successfully", async () => {
 			server.use(
 				// Auth endpoint
-				http.post("http://localhost:1337/auth/local", async ({ request }) => {
+				http.post("http://localhost:1337/api/auth/local", async ({ request }) => {
 					const body = await request.json();
 					expect(body).toEqual({
 						identifier: "test@example.com",
@@ -153,7 +154,7 @@ describe.runIf(majorNodeVersion >= 20)("strapiSource", () => {
 
 		it("should handle custom query objects", async () => {
 			server.use(
-				http.post("http://localhost:1337/auth/local", () => {
+				http.post("http://localhost:1337/api/auth/local", () => {
 					return HttpResponse.json({ jwt: "test-token" });
 				}),
 				http.get("http://localhost:1337/api/custom-content", ({ request }) => {
@@ -229,6 +230,237 @@ describe.runIf(majorNodeVersion >= 20)("strapiSource", () => {
 		});
 	});
 
+	describe("Strapi v5", () => {
+		it("should authenticate and fetch data successfully", async () => {
+			server.use(
+				// Auth endpoint
+				http.post("http://localhost:1337/api/auth/local", async ({ request }) => {
+					const body = await request.json();
+					expect(body).toEqual({
+						identifier: "test@example.com",
+						password: "password",
+					});
+
+					return HttpResponse.json({
+						jwt: "test-token",
+					});
+				}),
+				// Data endpoint
+				http.get("http://localhost:1337/api/test-content", ({ request }) => {
+					const authHeader = request.headers.get("Authorization");
+					expect(authHeader).toBe("Bearer test-token");
+
+					const url = new URL(request.url);
+					const page = Number.parseInt(url.searchParams.get("pagination[page]") || "1", 10);
+
+					// Return empty results after first page
+					if (page > 1) {
+						return HttpResponse.json({
+							data: [],
+							meta: {
+								pagination: {
+									page,
+									pageSize: 100,
+									pageCount: 1,
+									total: 1,
+								},
+							},
+						});
+					}
+
+					return HttpResponse.json({
+						data: [
+							{
+								id: 1,
+								documentId: "abc123def456",
+								title: "Test Content",
+								description: "Test Description",
+							},
+						],
+						meta: {
+							pagination: {
+								page: 1,
+								pageSize: 100,
+								pageCount: 1,
+								total: 1,
+							},
+						},
+					});
+				}),
+			);
+
+			const source = await strapiSource({
+				id: "test-strapi",
+				version: "5",
+				baseUrl: "http://localhost:1337",
+				identifier: "test@example.com",
+				password: "password",
+				queries: ["test-content"],
+			});
+
+			const result = source.fetch(createFetchContext());
+			expect(result).toHaveLength(1);
+
+			const data = (await result[0]!.data.next()).value;
+
+			expect(data).toMatchInlineSnapshot(`
+				[
+				  {
+				    "description": "Test Description",
+				    "documentId": "abc123def456",
+				    "id": 1,
+				    "title": "Test Content",
+				  },
+				]
+			`);
+
+			expect((await result[0]!.data.next()).done).toBe(true);
+		});
+
+		it("should handle custom query objects", async () => {
+			server.use(
+				http.post("http://localhost:1337/api/auth/local", () => {
+					return HttpResponse.json({ jwt: "test-token" });
+				}),
+				http.get("http://localhost:1337/api/custom-content", ({ request }) => {
+					const url = new URL(request.url);
+					expect(url.searchParams.get("filters[type][$eq]")).toBe("test");
+					expect(url.searchParams.get("sort[0]")).toBe("createdAt:desc");
+
+					if (url.searchParams.get("pagination[page]") === "2") {
+						return HttpResponse.json({
+							data: [],
+							meta: {
+								pagination: { page: 2, pageSize: 100, pageCount: 1, total: 0 },
+							},
+						});
+					}
+
+					return HttpResponse.json({
+						data: [
+							{
+								id: 1,
+								documentId: "xyz789uvw012",
+								title: "Custom Content",
+								type: "test",
+							},
+						],
+						meta: {
+							pagination: {
+								page: 1,
+								pageSize: 100,
+								pageCount: 1,
+								total: 1,
+							},
+						},
+					});
+				}),
+			);
+
+			const source = await strapiSource({
+				id: "test-strapi",
+				version: "5",
+				baseUrl: "http://localhost:1337",
+				identifier: "test@example.com",
+				password: "password",
+				queries: [
+					{
+						contentType: "custom-content",
+						params: {
+							"filters[type][$eq]": "test",
+							"sort[0]": "createdAt:desc",
+						},
+					},
+				],
+			});
+
+			const result = source.fetch(createFetchContext());
+
+			const data = (await result[0]!.data.next()).value;
+
+			expect(data).toMatchInlineSnapshot(`
+				[
+				  {
+				    "documentId": "xyz789uvw012",
+				    "id": 1,
+				    "title": "Custom Content",
+				    "type": "test",
+				  },
+				]
+			`);
+
+			expect((await result[0]!.data.next()).done).toBe(true);
+		});
+
+		it("should default to v4/v5-style behavior (not v3) when version is omitted", async () => {
+			server.use(
+				http.post("http://localhost:1337/api/auth/local", async ({ request }) => {
+					const body = await request.json();
+					expect(body).toEqual({
+						identifier: "test@example.com",
+						password: "password",
+					});
+
+					return HttpResponse.json({ jwt: "test-token" });
+				}),
+				http.get("http://localhost:1337/api/test-content", ({ request }) => {
+					const url = new URL(request.url);
+					const page = Number.parseInt(url.searchParams.get("pagination[page]") || "1", 10);
+
+					if (page > 1) {
+						return HttpResponse.json({
+							data: [],
+							meta: {
+								pagination: { page, pageSize: 100, pageCount: 1, total: 1 },
+							},
+						});
+					}
+
+					return HttpResponse.json({
+						data: [
+							{
+								id: 1,
+								documentId: "abc123def456",
+								title: "Test Content",
+							},
+						],
+						meta: {
+							pagination: {
+								page: 1,
+								pageSize: 100,
+								pageCount: 1,
+								total: 1,
+							},
+						},
+					});
+				}),
+			);
+
+			const source = await strapiSource({
+				id: "test-strapi",
+				baseUrl: "http://localhost:1337",
+				identifier: "test@example.com",
+				password: "password",
+				queries: ["test-content"],
+			});
+
+			const result = source.fetch(createFetchContext());
+			const data = (await result[0]!.data.next()).value;
+
+			expect(data).toMatchInlineSnapshot(`
+				[
+				  {
+				    "documentId": "abc123def456",
+				    "id": 1,
+				    "title": "Test Content",
+				  },
+				]
+			`);
+
+			expect((await result[0]!.data.next()).done).toBe(true);
+		});
+	});
+
 	describe("Strapi v3", () => {
 		it("should authenticate and fetch data successfully", async () => {
 			server.use(
@@ -294,7 +526,7 @@ describe.runIf(majorNodeVersion >= 20)("strapiSource", () => {
 
 	it("should handle authentication errors", async () => {
 		server.use(
-			http.post("http://localhost:1337/auth/local", () => {
+			http.post("http://localhost:1337/api/auth/local", () => {
 				return new HttpResponse("Invalid credentials", { status: 401 });
 			}),
 		);
@@ -313,7 +545,7 @@ describe.runIf(majorNodeVersion >= 20)("strapiSource", () => {
 
 	it("should handle API errors", async () => {
 		server.use(
-			http.post("http://localhost:1337/auth/local", () => {
+			http.post("http://localhost:1337/api/auth/local", () => {
 				return HttpResponse.json({ jwt: "test-token" });
 			}),
 			http.get("http://localhost:1337/api/test-content", () => {
@@ -340,7 +572,7 @@ describe.runIf(majorNodeVersion >= 20)("strapiSource", () => {
 		const ctx = createFetchContext();
 
 		server.use(
-			http.post("http://localhost:1337/auth/local", () => {
+			http.post("http://localhost:1337/api/auth/local", () => {
 				return HttpResponse.json({ jwt: "test-token" });
 			}),
 			http.get("http://localhost:1337/api/custom-content", async ({ request }) => {

--- a/packages/content/src/sources/strapi-source.ts
+++ b/packages/content/src/sources/strapi-source.ts
@@ -34,8 +34,8 @@ const strapiSourceSchema = z
 		id: z
 			.string()
 			.describe("Required field to identify this source. Will be used as download path."),
-		/** Strapi version. Defaults to `3`. */
-		version: z.enum(["3", "4"]).describe("Strapi version").default("3"),
+		/** Strapi version. Defaults to `5`. */
+		version: z.enum(["3", "4", "5"]).describe("Strapi version").default("5"),
 		/** The base url of your Strapi CMS (with or without trailing slash). */
 		baseUrl: z
 			.string()
@@ -186,6 +186,11 @@ class StrapiV4 extends StrapiVersionUtils {
 	}
 }
 
+// Strapi v5's REST API is identical to v4's for the purposes of this source:
+// pagination params/response shape are unchanged, and entries are passed through
+// as opaque `unknown[]` so v5's removal of the `attributes` nesting requires no code change.
+class StrapiV5 extends StrapiV4 {}
+
 class StrapiV3 extends StrapiVersionUtils {
 	override buildUrl(query: StrapiObjectQuery, pagination?: StrapiPagination): string {
 		const url = new URL(`/api/${query.contentType}`, this.config.baseUrl);
@@ -227,7 +232,9 @@ async function getToken(assembledOptions: StrapiSourceSchemaOutput) {
 		return assembledOptions.token;
 	}
 
-	const url = new URL("/auth/local", assembledOptions.baseUrl);
+	// v3 exposes login at `/auth/local`; v4 and v5 nest it under `/api`.
+	const authPath = assembledOptions.version === "3" ? "/auth/local" : "/api/auth/local";
+	const url = new URL(authPath, assembledOptions.baseUrl);
 	const response = await ky.post<{ jwt: string }>(url.toString(), {
 		json: { identifier: assembledOptions.identifier, password: assembledOptions.password },
 	});
@@ -246,19 +253,17 @@ export default async function strapiSource(options: z.input<typeof strapiSourceS
 
 	const assembledOptions = strapiSourceSchema.parse(options);
 
-	if (assembledOptions.version !== "4" && assembledOptions.version !== "3") {
-		throw new Error(`Unsupported strapi version '${assembledOptions.version}'`);
-	}
-
 	const token = await getToken(assembledOptions);
 
 	return defineSource({
 		id: assembledOptions.id,
 		fetch: (ctx) => {
 			const versionUtils: StrapiVersionUtils =
-				assembledOptions.version === "4"
-					? new StrapiV4(assembledOptions, ctx.logger)
-					: new StrapiV3(assembledOptions, ctx.logger);
+				assembledOptions.version === "5"
+					? new StrapiV5(assembledOptions, ctx.logger)
+					: assembledOptions.version === "4"
+						? new StrapiV4(assembledOptions, ctx.logger)
+						: new StrapiV3(assembledOptions, ctx.logger);
 
 			return assembledOptions.queries.map((query) => {
 				let parsedQuery: StrapiObjectQuery;


### PR DESCRIPTION
v5 keeps v4's pagination params and response envelope, so the v4 fetch path is reused; entries pass through unchanged (flattened shape with documentId).